### PR TITLE
Update all API requests to specify fields & includes 

### DIFF
--- a/packages/shift-next-routes/src/express/account-handler.js
+++ b/packages/shift-next-routes/src/express/account-handler.js
@@ -5,8 +5,7 @@ const { getSessionExpiryTime } = require('../lib/session')
 const accountApiEndpointQuery = {
   fields: {
     customer_accounts: 'email,meta_attributes'
-  },
-  include: ''
+  }
 }
 
 module.exports = {

--- a/packages/shift-next-routes/src/express/account-handler.js
+++ b/packages/shift-next-routes/src/express/account-handler.js
@@ -1,26 +1,24 @@
 // Shift-api client
 const { SHIFTClient } = require('@shiftcommerce/shift-node-api')
-
-// Lib
 const { getSessionExpiryTime } = require('../lib/session')
+
+const accountApiEndpointQuery = {
+  fields: {
+    customer_accounts: 'email,meta_attributes'
+  },
+  include: ''
+}
 
 module.exports = {
   getAccount: async (req, res) => {
     const { customerId } = req.session
+    req.query = { ...req.query, ...accountApiEndpointQuery }
 
     if (!customerId) {
       return res.status(200).send({})
     }
 
-    const params = {
-      fields: {
-        customer_accounts: 'email,meta_attributes'
-      },
-      // There are some default includes in the platform that we need this to ignore.
-      include: ''
-    }
-
-    const response = await SHIFTClient.getAccountV1(params, customerId)
+    const response = await SHIFTClient.getAccountV1(req.query, customerId)
 
     switch (response.status) {
       case 404:

--- a/packages/shift-next-routes/src/express/addressbook-handler.js
+++ b/packages/shift-next-routes/src/express/addressbook-handler.js
@@ -1,14 +1,21 @@
 const { SHIFTClient } = require('@shiftcommerce/shift-node-api')
 
+const addressBookApiEndpointQuery = {
+  fields: {
+    addresses: 'address_line_1,address_line_2,city,country,first_name,last_name,meta_attributes,postcode,preferred_billing,preferred_shipping,state',
+  }
+}
+
 module.exports = {
   getAddressBook: async (req, res) => {
+    req.query = { ...req.query, ...addressBookApiEndpointQuery }
     const { customerId } = req.session
 
     if (!customerId) {
       return res.status(200).send({})
     }
 
-    const response = await SHIFTClient.getAddressBookV1(customerId)
+    const response = await SHIFTClient.getAddressBookV1(customerId, req.query)
 
     switch (response.status) {
       case 404:

--- a/packages/shift-next-routes/src/express/cart-handler.js
+++ b/packages/shift-next-routes/src/express/cart-handler.js
@@ -31,7 +31,6 @@ module.exports = {
     }
   },
   addToCart: async (req, res) => {
-    req.query = { ...req.query, ...cartApiEndpointQuery }
     const cartId = req.signedCookies.cart
 
     let response

--- a/packages/shift-next-routes/src/express/category-handler.js
+++ b/packages/shift-next-routes/src/express/category-handler.js
@@ -1,8 +1,19 @@
 const { SHIFTClient } = require('@shiftcommerce/shift-node-api')
 const { setSurrogateHeaders } = require('../lib/set-cache-headers')
 
+const categoryApiEndpointQuery = {
+  fields: {
+    asset_files: 's3_url,canonical_path',
+    products: 'title,description,slug,canonical_path,reference,asset_files,min_price,max_price,min_current_price,max_current_price,rating,meta_attributes,updated_at',
+    variants: 'price,meta_attributes,sku,asset_files',
+    category_trees: 'path,slug'
+  },
+  include: 'asset_files,variants,bundles'
+}
+
 module.exports = {
   getCategory: async (req, res) => {
+    req.query = { ...req.query, ...categoryApiEndpointQuery }
     const response = await SHIFTClient.getCategoryV1(req.params.id, req.query)
 
     setSurrogateHeaders(response.headers, res)

--- a/packages/shift-next-routes/src/express/product-handler.js
+++ b/packages/shift-next-routes/src/express/product-handler.js
@@ -1,9 +1,19 @@
 const { SHIFTClient } = require('@shiftcommerce/shift-node-api')
 const { setSurrogateHeaders } = require('../lib/set-cache-headers')
 
+const productApiEndpointQuery = {
+  fields: {
+    asset_files: 'id,image_height,image_width,s3_url',
+    variants: 'id,meta_attributes,title,description,reference,ewis_eligible,product_id,sku,stock_allocated_level,stock_level,tax_code,stock_available_level,has_assets,price_includes_taxes,available_to_order,price,current_price,picture_url'
+  },
+  include: 'asset_files,variants,template,meta.*'
+}
+
 module.exports = {
   getProductById: async (req, res) => {
-    const response = await SHIFTClient.getProductV1(req.params.id, req.query)
+    req.query = { ...req.query, ...productApiEndpointQuery }
+    const productId = req.params.id
+    const response = await SHIFTClient.getProductV1(productId, req.query)
 
     setSurrogateHeaders(response.headers, res)
 

--- a/packages/shift-next-routes/test/express/addressbook-handler.test.js
+++ b/packages/shift-next-routes/test/express/addressbook-handler.test.js
@@ -44,6 +44,11 @@ describe('getAddressBook()', () => {
     const req = {
       session: {
         customerId: 77
+      },
+      query: {
+        fields: {
+          addresses: 'address_line_1,address_line_2,city,country,first_name,last_name,meta_attributes,postcode,preferred_billing,preferred_shipping,state',
+        }
       }
     }
 
@@ -55,11 +60,13 @@ describe('getAddressBook()', () => {
 
     nock(process.env.API_HOST)
       .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-headers': 'Authorization' })
-      .options('/test_tenant/v1/customer_accounts/77/addresses')
+      .options(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses`)
+      .query(req.query)
       .reply(200)
 
     nock(process.env.API_HOST)
-      .get('/test_tenant/v1/customer_accounts/77/addresses')
+      .get(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses`)
+      .query(req.query)
       .reply(200, addressBookResponse)
 
     const response = await getAddressBook(req, res)
@@ -98,11 +105,11 @@ describe('createAddressBookEntry()', () => {
 
     nock(process.env.API_HOST)
       .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-headers': 'Authorization' })
-      .options('/test_tenant/v1/customer_accounts/77/addresses')
+      .options(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses`)
       .reply(200)
 
     nock(process.env.API_HOST)
-      .post('/test_tenant/v1/customer_accounts/77/addresses')
+      .post(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses`)
       .reply(201, createAddressBookEntryRequest)
 
     const response = await createAddressBookEntry(req, res)
@@ -148,11 +155,11 @@ describe('deleteAddress()', () => {
 
     nock(process.env.API_HOST)
       .defaultReplyHeaders({ 'access-control-allow-origin': '*', 'access-control-allow-headers': 'Authorization' })
-      .options('/test_tenant/v1/customer_accounts/77/addresses/469')
+      .options(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses/${req.params.addressId}`)
       .reply(200)
 
     nock(process.env.API_HOST)
-      .delete('/test_tenant/v1/customer_accounts/77/addresses/469')
+      .delete(`/test_tenant/v1/customer_accounts/${req.session.customerId}/addresses/${req.params.addressId}`)
       .reply(204)
 
     const response = await deleteAddress(req, res)

--- a/packages/shift-next/src/actions/account-actions.js
+++ b/packages/shift-next/src/actions/account-actions.js
@@ -6,7 +6,6 @@ import { readEndpoint, postEndpoint } from './api-actions'
 
 const accountRequest = {
   endpoint: '/getAccount',
-  query: {},
   errorActionType: types.ERROR_ACCOUNT,
   requestActionType: types.GET_ACCOUNT,
   successActionType: types.SET_ACCOUNT

--- a/packages/shift-next/src/actions/product-actions.js
+++ b/packages/shift-next/src/actions/product-actions.js
@@ -11,7 +11,5 @@ const productRequest = (productId) => {
 }
 
 export function readProduct (productId) {
-  return (dispatch) => {
-    return dispatch(readEndpoint(productRequest(productId)))
-  }
+  return readEndpoint(productRequest(productId))
 }

--- a/packages/shift-next/src/actions/product-actions.js
+++ b/packages/shift-next/src/actions/product-actions.js
@@ -5,15 +5,13 @@ import * as types from './action-types'
 const productRequest = (productId) => {
   return {
     endpoint: `/getProduct/${productId}`,
-    query: {
-      include: 'asset_files,variants,bundles,bundles.asset_files,template,meta.*',
-      fields: { asset_files: 'image_height,image_width,s3_url' }
-    },
     requestActionType: types.GET_PRODUCT,
     successActionType: types.SET_PRODUCT
   }
 }
 
 export function readProduct (productId) {
-  return readEndpoint(productRequest(productId))
+  return (dispatch) => {
+    return dispatch(readEndpoint(productRequest(productId)))
+  }
 }

--- a/packages/shift-next/src/lib/api-client.js
+++ b/packages/shift-next/src/lib/api-client.js
@@ -35,7 +35,7 @@ class ApiClient {
     }
   }
 
-  async post(endpoint, body = {}, dispatch = null, options = {}) {
+  async post (endpoint, body = {}, dispatch = null, options = {}) {
     try {
       shouldDispatch(dispatch, true)
       const response = await this.client.post(endpoint, body)
@@ -48,7 +48,7 @@ class ApiClient {
     }
   }
 
-  async delete(endpoint, dispatch = null, options = {}) {
+  async delete (endpoint, dispatch = null, options = {}) {
     try {
       shouldDispatch(dispatch, true)
       const response = await this.client.delete(endpoint)

--- a/packages/shift-next/src/pages/static-page.js
+++ b/packages/shift-next/src/pages/static-page.js
@@ -61,7 +61,7 @@ class StaticPage extends Component {
 
     return (
       <this.Head>
-        { homepage ? <title>{Config.get().storeName}</title> : <title>{suffixWithStoreName(title)}</title> }
+        { homepage ? <title>{ Config.get().storeName }</title> : <title>{ suffixWithStoreName(title) }</title> }
       </this.Head>
     )
   }

--- a/packages/shift-node-api/README.md
+++ b/packages/shift-node-api/README.md
@@ -77,7 +77,7 @@ Once the config has been defined you should be able to use `SHIFTClient`
 
 **getCustomerOrdersV1(query)**
 
-**getAddressBookV1(customerAccountId)**
+**getAddressBookV1(customerAccountId, query)**
 
 **createAddressBookEntryV1(body, customerAccountId)**
 

--- a/packages/shift-node-api/src/endpoints/account-endpoints.js
+++ b/packages/shift-node-api/src/endpoints/account-endpoints.js
@@ -40,8 +40,8 @@ function getCustomerOrdersV1 (query) {
   })
 }
 
-function getAddressBookV1 (customerAccountId) {
-  return HTTPClient.get(`v1/customer_accounts/${customerAccountId}/addresses`)
+function getAddressBookV1 (customerAccountId, query) {
+  return HTTPClient.get(`v1/customer_accounts/${customerAccountId}/addresses`, query)
 }
 
 function createAddressBookEntryV1 (body, customerAccountId) {

--- a/packages/shift-node-api/src/shift-client.js
+++ b/packages/shift-node-api/src/shift-client.js
@@ -147,8 +147,8 @@ class SHIFTClient {
     return accountEndpoints.getCustomerOrdersV1(query)
   }
 
-  getAddressBookV1 (customerAccountId) {
-    return accountEndpoints.getAddressBookV1(customerAccountId)
+  getAddressBookV1 (customerAccountId, query) {
+    return accountEndpoints.getAddressBookV1(customerAccountId, query)
       .then(this.determineResponse)
   }
 

--- a/packages/shift-node-api/test/src/endpoints/account-endpoints.spec.js
+++ b/packages/shift-node-api/test/src/endpoints/account-endpoints.spec.js
@@ -45,8 +45,7 @@ describe('getAccountV1', () => {
     const queryObject = {
       fields: {
         customer_accounts: 'email,meta_attributes'
-      },
-      include: ''
+      }
     }
 
     const accountData = {
@@ -162,11 +161,19 @@ describe('getCustomerOrdersV1', () => {
 
 describe('getAddressBookV1', () => {
   test('endpoint returns address book with correct id', () => {
+    const customerId = '77'
+    const queryObject = {
+      fields: {
+        addresses: 'address_line_1,address_line_2,city,country,first_name,last_name,meta_attributes,postcode,preferred_billing,preferred_shipping,state',
+      }
+    }
+
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/customer_accounts/77/addresses`)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/customer_accounts/${customerId}/addresses`)
+      .query(queryObject)
       .reply(200, addressBookResponse)
 
-    return getAddressBookV1(77)
+    return getAddressBookV1(customerId, queryObject)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(addressBookResponse)

--- a/packages/shift-node-api/test/src/endpoints/category-endpoints.spec.js
+++ b/packages/shift-node-api/test/src/endpoints/category-endpoints.spec.js
@@ -8,6 +8,16 @@ const { shiftApiConfig } = require('../../../src/index')
 const categoryResponse = require('../../fixtures/category-response')
 const categoryQueryResponse = require('../../fixtures/category-query-response')
 
+const categoryDefaultQuery = {
+  fields: {
+    asset_files: 's3_url,canonical_path',
+    products: 'title,description,slug,canonical_path,reference,asset_files,min_price,max_price,min_current_price,max_current_price,rating,meta_attributes,updated_at',
+    variants: 'price,meta_attributes,sku,asset_files',
+    category_trees: 'path,slug'
+  },
+  include: 'asset_files,variants,bundles'
+}
+
 axios.defaults.adapter = httpAdapter
 
 beforeEach(() => {
@@ -21,11 +31,14 @@ afterEach(() => { nock.cleanAll() })
 
 describe('getCategoryV1', () => {
   test('returns a category when given a correct id', () => {
+    const categoryId = '56'
+
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/category_trees/reference:web/categories/56`)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/category_trees/reference:web/categories/${categoryId}`)
+      .query(categoryDefaultQuery)
       .reply(200, categoryResponse)
 
-    return getCategoryV1(56)
+    return getCategoryV1(categoryId, categoryDefaultQuery)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(categoryResponse)

--- a/packages/shift-node-api/test/src/endpoints/menu-endpoints.spec.js
+++ b/packages/shift-node-api/test/src/endpoints/menu-endpoints.spec.js
@@ -7,6 +7,21 @@ const { shiftApiConfig } = require('../../../src/index')
 // Fixtures
 const menuResponse = require('../../fixtures/menu-response-payload')
 
+const menuDefaultQuery = {
+  fields: {
+    menu_items: 'title,slug,menu_items,item,background_image_link,background_image,published,canonical_path,meta_attributes',
+    menus: 'title,reference,updated_at,menu_items'
+  },
+  filter: {
+    filter: {
+      reference: {
+        eq: 'mega-menu'
+      }
+    }
+  },
+  include: 'menu_items'
+}
+
 axios.defaults.adapter = httpAdapter
 
 beforeEach(() => {
@@ -20,27 +35,13 @@ afterEach(() => { nock.cleanAll() })
 
 describe('getMenusV1', () => {
   test('returns a correct response with a valid query', () => {
-    const query = {
-      fields: {
-        menu_items: 'title,slug,menu_items,item,background_image_link,background_image,published,canonical_path,meta_attributes',
-        menus: 'title,reference,updated_at,menu_items'
-      },
-      filter: {
-        filter: {
-          reference: {
-            eq: 'mega-menu'
-          }
-        }
-      },
-      include: 'menu_items'
-    }
 
     nock(shiftApiConfig.get().apiHost)
       .get(`/${shiftApiConfig.get().apiTenant}/v1/menus`)
-      .query(true)
+      .query(menuDefaultQuery)
       .reply(200, menuResponse)
 
-    return getMenusV1(query)
+    return getMenusV1(menuDefaultQuery)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(menuResponse)
@@ -48,27 +49,13 @@ describe('getMenusV1', () => {
   })
 
   test('returns an error when called with an invalid query', () => {
-    const query = {
-      fields: {
-        menu_items: 'title,slug,menu_items,item,background_image_link,background_image,published,canonical_path,meta_attributes',
-        menus: 'title,reference,updated_at,menu_items'
-      },
-      filter: {
-        filter: {
-          reference: {
-            e: 'mega-menu'
-          }
-        }
-      },
-      include: 'menu_items'
-    }
 
     nock(shiftApiConfig.get().apiHost)
       .get(`/${shiftApiConfig.get().apiTenant}/v1/menus`)
       .query(true)
       .reply(500)
 
-    return getMenusV1(query)
+    return getMenusV1(menuDefaultQuery)
       .catch(error => {
         expect(error).toEqual(new Error('Request failed with status code 500'))
       })

--- a/packages/shift-node-api/test/src/endpoints/product-endpoints.spec.js
+++ b/packages/shift-node-api/test/src/endpoints/product-endpoints.spec.js
@@ -7,6 +7,14 @@ const { shiftApiConfig } = require('../../../src/index')
 // Fixtures
 const productResponse = require('../../fixtures/product-response-payload')
 
+const productDefaultQuery = {
+  fields: {
+    asset_files: 'id,image_height,image_width,s3_url',
+    variants: 'id,meta_attributes,title,description,reference,ewis_eligible,product_id,sku,stock_allocated_level,stock_level,tax_code,stock_available_level,has_assets,price_includes_taxes,available_to_order,price,current_price,picture_url'
+  },
+  include: 'asset_files,variants,template,meta.*'
+}
+
 axios.defaults.adapter = httpAdapter
 
 beforeEach(() => {
@@ -20,17 +28,14 @@ afterEach(() => { nock.cleanAll() })
 
 describe('getProductV1', () => {
   test('returns a product when given a correct id', () => {
-    const queryObject = {
-      include: 'asset_files,variants,bundles,bundles.asset_files,template,meta.*',
-      fields: { asset_files: 'image_height,image_width,s3_url' }
-    }
+    const productId = '172'
 
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/products/172`)
-      .query(queryObject)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/products/${productId}`)
+      .query(productDefaultQuery)
       .reply(200, productResponse)
 
-    return getProductV1(172, queryObject)
+    return getProductV1(productId, productDefaultQuery)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(productResponse)
@@ -38,19 +43,16 @@ describe('getProductV1', () => {
   })
 
   test('returns an error with incorrect id', () => {
-    const queryObject = {
-      include: 'asset_files,variants,bundles,bundles.asset_files,template,meta.*',
-      fields: { asset_files: 'image_height,image_width,s3_url' }
-    }
+    const productId = '200000'
 
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/products/20000`)
-      .query(queryObject)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/products/${productId}`)
+      .query(productDefaultQuery)
       .reply(404, {
         'errors': [
           {
             'title': 'Record not found',
-            'detail': 'The record identified by 20000 could not be found.',
+            'detail': 'The record identified by 200000 could not be found.',
             'code': '404',
             'status': '404'
           }
@@ -62,7 +64,7 @@ describe('getProductV1', () => {
 
     expect.assertions(2)
 
-    return getProductV1(20000, queryObject)
+    return getProductV1(productId, productDefaultQuery)
       .catch(error => {
         expect(error).toEqual(new Error('Request failed with status code 404'))
         expect(error.response.data.errors[0].title).toEqual('Record not found')

--- a/packages/shift-node-api/test/src/endpoints/static-page-endpoints.spec.js
+++ b/packages/shift-node-api/test/src/endpoints/static-page-endpoints.spec.js
@@ -10,6 +10,10 @@ const parser = require('../../../src/lib/json-api-parser')
 const staticPageResponse = require('../../fixtures/staticpage-response')
 const articleStaticPageResponse = require('../../fixtures/article-staticpage-response')
 
+const staticPageDefaultQuery = {
+  include: 'template,meta.*'
+}
+
 axios.defaults.adapter = httpAdapter
 
 beforeEach(() => {
@@ -23,16 +27,14 @@ afterEach(() => { nock.cleanAll() })
 
 describe('getStaticPagesV1', () => {
   test('endpoint returns a static page with correct id', () => {
-    const queryObject = {
-      include: 'template,meta.*'
-    }
+    const staticPageId = '56'
 
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/static_pages/56`)
-      .query(queryObject)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/static_pages/${staticPageId}`)
+      .query(staticPageDefaultQuery)
       .reply(200, staticPageResponse)
 
-    return getStaticPageV1(56, queryObject)
+    return getStaticPageV1(staticPageId, staticPageDefaultQuery)
       .then(response => {
         expect(response.status).toEqual(200)
         expect(response.data).toEqual(staticPageResponse)
@@ -40,13 +42,11 @@ describe('getStaticPagesV1', () => {
   })
 
   test('endpoint returns an error with incorrect id', () => {
-    const queryObject = {
-      include: 'template,meta.*'
-    }
+    const staticPageId = '1001'
 
     nock(shiftApiConfig.get().apiHost)
-      .get(`/${shiftApiConfig.get().apiTenant}/v1/static_pages/1001`)
-      .query(queryObject)
+      .get(`/${shiftApiConfig.get().apiTenant}/v1/static_pages/${staticPageId}`)
+      .query(staticPageDefaultQuery)
       .reply(404, {
         errors: [
           {
@@ -61,7 +61,7 @@ describe('getStaticPagesV1', () => {
         }
       })
 
-    return getStaticPageV1(1001, queryObject)
+    return getStaticPageV1(staticPageId, staticPageDefaultQuery)
       .catch(error => {
         expect(error.response.status).toBe(404)
         expect(error.response.data.errors[0].title).toEqual('Record not found')

--- a/packages/shift-react-components/__tests__/components/checkout/__snapshots__/shipping-methods.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/checkout/__snapshots__/shipping-methods.spec.js.snap
@@ -173,7 +173,7 @@ exports[`renders error messages 1`] = `
             <span
               className="c-shipping-method__list-delivery-date"
             >
-              Monday 27th May
+              Monday 3rd June
             </span>
           </label>
         </div>
@@ -218,7 +218,7 @@ exports[`renders error messages 1`] = `
             <span
               className="c-shipping-method__list-delivery-date"
             >
-              Monday 27th May
+              Monday 3rd June
             </span>
           </label>
         </div>
@@ -263,7 +263,7 @@ exports[`renders error messages 1`] = `
             <span
               className="c-shipping-method__list-delivery-date"
             >
-              Monday 27th May
+              Monday 3rd June
             </span>
           </label>
         </div>
@@ -308,7 +308,7 @@ exports[`renders error messages 1`] = `
             <span
               className="c-shipping-method__list-delivery-date"
             >
-              Monday 27th May
+              Monday 3rd June
             </span>
           </label>
         </div>


### PR DESCRIPTION
### Overview

Related GitHub issue: https://github.com/shiftcommerce/shift-node-api/issues/26

This PR updates the reference sites API requests to specify fields and includes. This means we now receive only the data we require from the API. This should lower CPU and memory consumption and therefore improve performance.

