### PR TITLE
Clean up

### DIFF
--- a/packages/reference/.env.example
+++ b/packages/reference/.env.example
@@ -23,7 +23,7 @@ SESSSION_EXPIRY=<session_expiry_time_in_seconds> Not required but can be configu
 LOG_LEVEL=info
 
 # A comma-separated list of hosts to whitelist in the CSP header
-CONNECT_SCRIPTS=<https://host1.example.com,https://host2.example.com>
+CONNECT_HOSTS=<https://host1.example.com,https://host2.example.com>
 FRAME_HOSTS=<https://host1.example.com,https://host2.example.com>
 IMAGE_HOSTS=<https://host1.example.com,https://host2.example.com>
 SCRIPT_HOSTS=<https://host1.example.com,https://host2.example.com>


### PR DESCRIPTION
### Overview

Related GitHub issue: shiftcommerce/trendy-golf#161

PR simply renames the env var `CONNECT_SCRIPTS` to `CONNECT_HOSTS` and removes logic for removing the `X-Powered-By` header, which is now handled in `shift-next-routes`

![Screenshot 2019-06-07 at 11 30 46](https://user-images.githubusercontent.com/4486874/59098286-c2628380-8917-11e9-9244-1994e59baa6c.png)
