### PR TITLE
Hotfix/Added category_ids_cache to cartApiEndpointQuery

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.6",
+  "version": "0.22.7",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.6",
-    "@shiftcommerce/shift-next-routes": "^0.22.6",
-    "@shiftcommerce/shift-react-components": "^0.22.6",
+    "@shiftcommerce/shift-next": "^0.22.7",
+    "@shiftcommerce/shift-next-routes": "^0.22.7",
+    "@shiftcommerce/shift-react-components": "^0.22.7",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.6",
+    "@shiftcommerce/shift-node-api": "^0.22.7",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next-routes/src/express/cart-handler.js
+++ b/packages/shift-next-routes/src/express/cart-handler.js
@@ -6,7 +6,7 @@ const cartApiEndpointQuery = {
   fields: {
     line_items: 'line_item_discounts,sku,stock_available_level,sub_total,tax_rate,title,total,total_discount,item,unit_price,unit_quantity',
     variants: 'title,sku,price,price_includes_taxes,picture_url,stock_allocated_level,meta_attributes,product',
-    products: 'title,sku,slug,canonical_path,picture_url,meta_attributes',
+    products: 'title,sku,slug,canonical_path,picture_url,meta_attributes,category_ids_cache',
     line_item_discounts: 'line_item_number,promotion_id,total',
     discount_summaries: 'name,promotion_id,total',
     customer_account: 'email,meta_attributes,reference',

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.6",
-    "@shiftcommerce/shift-react-components": "^0.22.6",
+    "@shiftcommerce/shift-node-api": "^0.22.7",
+    "@shiftcommerce/shift-react-components": "^0.22.7",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",


### PR DESCRIPTION
Related PR in Trendy: https://github.com/shiftcommerce/trendy-golf/pull/217

Adds `category_ids_cache` to the Cart API call for products, so that we can get the IDs that the products in the cart belongs to