### PR TITLE
Amend the staticpage logic

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.9",
+  "version": "0.22.10",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/.circleci/cypress.js
+++ b/packages/reference/.circleci/cypress.js
@@ -1,7 +1,7 @@
 const glob = require('glob')
 const { CIRCLE_NODE_INDEX, CIRCLE_NODE_TOTAL } = process.env
 
-const files = glob.sync('cypress/integration/**/*.js', { nosort: true }).sort(() => Math.random() - 0.5)
+const files = glob.sync('cypress/integration/**/*.js')
 
 const groupSize = Math.ceil(files.length / parseInt(CIRCLE_NODE_TOTAL))
 const groupOffset = parseInt(CIRCLE_NODE_INDEX) * groupSize

--- a/packages/reference/cypress/support/commands/products.js
+++ b/packages/reference/cypress/support/commands/products.js
@@ -43,8 +43,6 @@ Cypress.Commands.add('goToPdpFromPlp', () => {
   // Click product
   cy.contains(/Regular Computer/i).click()
 
-  cy.wait('@getSlug')
-
   // Check the PDP was loaded
   cy.contains(/Product Details/i)
 })

--- a/packages/reference/next.config.js
+++ b/packages/reference/next.config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const path = require('path')
 const withSass = require('@zeit/next-sass')
 const withCSS = require('@zeit/next-css')

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.9",
-    "@shiftcommerce/shift-next-routes": "^0.22.9",
-    "@shiftcommerce/shift-react-components": "^0.22.9",
+    "@shiftcommerce/shift-next": "^0.22.10",
+    "@shiftcommerce/shift-next-routes": "^0.22.10",
+    "@shiftcommerce/shift-react-components": "^0.22.10",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -44,6 +44,7 @@
     "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-beta.3",
     "css-loader": "^1.0.1",
+    "dotenv": "^8.0.0",
     "express": "^4.16.2",
     "express-pino-logger": "^4.0.0",
     "file-loader": "^1.1.5",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.9",
+    "@shiftcommerce/shift-node-api": "^0.22.10",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.9",
-    "@shiftcommerce/shift-react-components": "^0.22.9",
+    "@shiftcommerce/shift-node-api": "^0.22.10",
+    "@shiftcommerce/shift-react-components": "^0.22.10",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-next/src/pages/slug.js
+++ b/packages/shift-next/src/pages/slug.js
@@ -22,9 +22,10 @@ const slugRequest = (slug) => {
       slugs: 'resource_type,resource_id,active,slug'
     }
   }
-  const query = qs.stringify(queryObject)
+
   return {
-    endpoint: `/getSlug/?${query}`
+    endpoint: '/getSlug',
+    query: queryObject
   }
 }
 
@@ -37,6 +38,11 @@ class Slug extends Component {
     const resourceType = t(response, 'data.resource_type').safeObject.toLowerCase()
     const resourceId = t(response, 'data.resource_id').safeObject
     let url = query.slug
+
+    // Temporary fix for Trendy
+    if (url === 'pages/homepage') {
+      url = '/'
+    }
 
     if (url === '/homepage') {
       url = '/'

--- a/packages/shift-next/test/pages/slug.test.js
+++ b/packages/shift-next/test/pages/slug.test.js
@@ -4,26 +4,26 @@ import nock from 'nock'
 import axios from 'axios'
 import httpAdapter from 'axios/lib/adapters/http'
 
+import Config from '../../src/lib/config'
+
 // Pages
 import Slug from '../../src/pages/slug'
 
 // Shared constants
-const resourceType = 'staticpage'
+const resourceType = 'StaticPage'
 const resourceId = 1
-
-jest.mock('next/config', () => () => ({
-  publicRuntimeConfig: {}
-}))
 
 axios.defaults.adapter = httpAdapter
 
 beforeEach(() => {
-  nock('http://localhost', { 'encodedQueryParams': true })
-    .get('/getSlug/')
+  Config.set({ apiHostProxy: 'http://example.com' })
+
+  nock(/example\.com/)
+    .get('/getSlug')
     .query(true)
     .reply(200, {
-      'resource_id': 1,
-      'resource_type': 'StaticPage'
+      'resource_id': resourceId,
+      'resource_type': resourceType
     }, ['access-control-allow-origin', '*'])
 })
 

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",

--- a/packages/shift-react-components/src/components/account/my-account-header.js
+++ b/packages/shift-react-components/src/components/account/my-account-header.js
@@ -4,12 +4,13 @@ import React, { Component } from 'react'
 // Lib
 import { Button } from '../../objects/button'
 import Config from '../../lib/config'
+import Link from '../../objects/link'
 
 export class MyAccountHeader extends Component {
   constructor (props) {
     super(props)
 
-    this.Link = Config.get().Link
+    this.Link = Config.get().Link || Link
   }
 
   renderLogout () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5801,10 +5801,15 @@ dotenv@^5.0.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
-dotenv@^6.0.0, dotenv@^6.2.0:
+dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
 
 download@^6.2.2:
   version "6.2.5"
@@ -11834,13 +11839,6 @@ neo-async@^2.5.0, neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-next-runtime-dotenv@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/next-runtime-dotenv/-/next-runtime-dotenv-1.1.1.tgz#ba5d4a544cdd5a88d92540dec851200c46809232"
-  integrity sha512-scsStSsjCMwK2zBvOhDP58tz8FV3Iw8xlVo0EuluxCzKGPJZoPxhV/7HLtsYrywagncZQ8bvF1dfKW0tXrfOMQ==
-  dependencies:
-    dotenv "^6.0.0"
 
 next-server@8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## Description

I've amended the logic in static page to take into account that Trendy uses the `/pages` prefix on all static pages. I believe at one point some one has manually amended the database to fix the slug specifically for that one page, and recently we've updated the homepage and it's re-written the slug to use `pages/homepage`

I noticed on Trendy that clientside navigation to the homepage was broken.

## Related Issue

N/A

### Checklist

- [ ] Appropriate commenting on functions/components (JSDoc format).
- [ ] All SHIFT library versions bumped and published (utilised in this PR).
- [ ] Unit tests added/amended.
- [ ] Integration tests added/amended.
- [ ] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

* Describe if there are any methodologies on how to potentially break the functionality
* Describe how to test the change(s) here
* Include steps you have taken locally to ensure that the code you are implementing works as expected
* How to test any other functionality that shares this code

### Dependencies Review

* Describe any new dependencies here
* List any new APIs required
* List any changes required in the Admin Panel
