### PR TITLE
Feature: Custom Shift Next Reducers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.10",
+  "version": "0.22.11",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.10",
-    "@shiftcommerce/shift-next-routes": "^0.22.10",
-    "@shiftcommerce/shift-react-components": "^0.22.10",
+    "@shiftcommerce/shift-next": "^0.22.11",
+    "@shiftcommerce/shift-next-routes": "^0.22.11",
+    "@shiftcommerce/shift-react-components": "^0.22.11",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.10",
+    "@shiftcommerce/shift-node-api": "^0.22.11",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.10",
-    "@shiftcommerce/shift-react-components": "^0.22.10",
+    "@shiftcommerce/shift-node-api": "^0.22.11",
+    "@shiftcommerce/shift-react-components": "^0.22.11",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-next/src/reducers/root-reducer.js
+++ b/packages/shift-next/src/reducers/root-reducer.js
@@ -1,6 +1,9 @@
 // Libraries
 import { combineReducers } from 'redux'
 
+// Libs
+import Config from '../lib/config'
+
 // Reducers
 import setAccount from './set-account'
 import setCart from './set-cart'
@@ -14,6 +17,8 @@ import setRegistration from './set-registration'
 import setSearchState from './set-search-state'
 import globalReducer from './global-reducer'
 
+const customReducers = Config.get().customReducers || {}
+
 const rootReducer = combineReducers({
   account: setAccount,
   cart: setCart,
@@ -25,7 +30,8 @@ const rootReducer = combineReducers({
   orders: setOrders,
   product: setProduct,
   registration: setRegistration,
-  search: setSearchState
+  search: setSearchState,
+  ...customReducers
 })
 
 export default rootReducer

--- a/packages/shift-next/test/reducers/root-reducer.test.js
+++ b/packages/shift-next/test/reducers/root-reducer.test.js
@@ -7,10 +7,11 @@ import Config from '../../src/lib/config'
 describe('Root Reducer', () => {    
   test('it merges custom reducers', () => {
     // Arrange
-    const customReducer = jest.fn(() => { return { test: true } })
+    const customReducer1 = jest.fn(() => { return { test: true } })
+    const customReducer2 = jest.fn(() => { return { testing: true } })
 
     Config.set({
-      customReducers: { customReducer }
+      customReducers: { customReducer1, customReducer2 }
     })
 
     // require reducer after config setup
@@ -22,8 +23,7 @@ describe('Root Reducer', () => {
 
     // Assert
     // check the customReducer initial state has been set
-    expect(state.customReducer).toEqual({
-      test: true
-    })
+    expect(state.customReducer1).toEqual({ test: true })
+    expect(state.customReducer2).toEqual({ testing: true })
   })
 })

--- a/packages/shift-next/test/reducers/root-reducer.test.js
+++ b/packages/shift-next/test/reducers/root-reducer.test.js
@@ -1,0 +1,29 @@
+// Libraries
+import { createStore } from 'redux'
+
+// Config
+import Config from '../../src/lib/config'
+
+describe('Root Reducer', () => {    
+  test('it merges custom reducers', () => {
+    // Arrange
+    const customReducer = jest.fn(() => { return { test: true } })
+
+    Config.set({
+      customReducers: { customReducer }
+    })
+
+    // require reducer after config setup
+    const rootReducer = require('../../src/reducers/root-reducer').default
+
+    // Act
+    const store = createStore(rootReducer)
+    const state = store.getState()
+
+    // Assert
+    // check the customReducer initial state has been set
+    expect(state.customReducer).toEqual({
+      test: true
+    })
+  })
+})

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",


### PR DESCRIPTION
## Description

PR adds the ability to merge custom reducers set via the `ShiftNextConfig`.

```jsx
import { shiftNextConfig } from '@shiftcommerce/shift-next'
import newsletterReducer from '../some/path/newsletter-reducer'

shiftNextConfig.set({
  ...
  customReducers: { newsletterReducer }
})
```

The change is required for the Trendy specific requirement -
> I should be able to sign-up for the newsletter via the mega navigation

## Related Issue

https://github.com/shiftcommerce/trendy-golf/issues/131

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [x] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [ ] Integration tests added/amended.
- [ ] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

N/A

### Dependencies Review

N/A
