### PR TITLE
make menu only ever load once

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.11",
+  "version": "0.22.12",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/cypress/integration/search/price-filter.js
+++ b/packages/reference/cypress/integration/search/price-filter.js
@@ -27,7 +27,6 @@ describe('Search', () => {
       }).as('algoliaSearch')
 
       // Wait for page to load
-      cy.wait('@getMenus')
       cy.wait('@algoliaSearch').then((xhr) => {
         assert.equal(xhr.responseBody.results[0].nbHits, 6, 'values equal')
       })

--- a/packages/reference/cypress/support/global-stubs.js
+++ b/packages/reference/cypress/support/global-stubs.js
@@ -14,6 +14,14 @@ beforeEach(() => {
     response: "{'events': [], 'meta': '{}'}"
   }).as('payPalLogger')
 
+  // Stub get menus request
+  cy.route({
+    method: 'GET',
+    url: '/getMenus?**',
+    status: 200,
+    response: 'fixture:menus/get-menus.json'
+  }).as('getMenus')
+
   // Stub geeky computer image request
   cy.route({
     method: 'GET',

--- a/packages/reference/cypress/support/global-stubs.js
+++ b/packages/reference/cypress/support/global-stubs.js
@@ -14,14 +14,6 @@ beforeEach(() => {
     response: "{'events': [], 'meta': '{}'}"
   }).as('payPalLogger')
 
-  // Stub get menus request
-  cy.route({
-    method: 'GET',
-    url: '/getMenus?**',
-    status: 200,
-    response: 'fixture:menus/get-menus.json'
-  }).as('getMenus')
-
   // Stub geeky computer image request
   cy.route({
     method: 'GET',

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.11",
-    "@shiftcommerce/shift-next-routes": "^0.22.11",
-    "@shiftcommerce/shift-react-components": "^0.22.11",
+    "@shiftcommerce/shift-next": "^0.22.12",
+    "@shiftcommerce/shift-next-routes": "^0.22.12",
+    "@shiftcommerce/shift-react-components": "^0.22.12",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.11",
+    "@shiftcommerce/shift-node-api": "^0.22.12",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.11",
-    "@shiftcommerce/shift-react-components": "^0.22.11",
+    "@shiftcommerce/shift-node-api": "^0.22.12",
+    "@shiftcommerce/shift-react-components": "^0.22.12",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-next/src/actions/menu-actions.js
+++ b/packages/shift-next/src/actions/menu-actions.js
@@ -5,4 +5,3 @@ import { readEndpoint } from './api-actions'
 export function readMenu (request) {
   return readEndpoint(request)
 }
-

--- a/packages/shift-next/src/lib/with-redux-store.js
+++ b/packages/shift-next/src/lib/with-redux-store.js
@@ -34,9 +34,13 @@ export default (App) => {
       // This allows you to set a custom default initialState
       const reduxStore = getOrCreateStore()
       reduxStore.dispatch(toggleLoading(true))
-      await reduxStore.dispatch(readMenu(Config.get().menuRequest))
+
       // Provide the store to getInitialProps of pages
       appContext.reduxStore = reduxStore
+
+      if (!reduxStore.getState().menu.loaded) {
+        await reduxStore.dispatch(readMenu(Config.get().menuRequest))
+      }
 
       // Get initial props from the parent
       let appProps = await Object.getPrototypeOf(this).getInitialProps(appContext)

--- a/packages/shift-next/src/reducers/set-menu.js
+++ b/packages/shift-next/src/reducers/set-menu.js
@@ -2,18 +2,19 @@
 import * as types from '../actions/action-types'
 
 export const initialState = {
-  loading: true,
+  loading: false,
+  loaded: false,
   error: false
 }
 
 export default function setMenu (state = initialState, action) {
   switch (action.type) {
     case types.GET_MENU:
-      return Object.assign({}, state)
+      return Object.assign({}, state, action.payload, { loading: true, error: false, loaded: false })
     case types.SET_MENU:
-      return Object.assign({}, state, action.payload, { loading: false })
+      return Object.assign({}, state, action.payload, { loading: false, loaded: true, error: false })
     case types.ERROR_MENU:
-      return Object.assign({}, state, action.payload, { error: true })
+      return Object.assign({}, state, action.payload, { error: true, loading: false, loaded: false })
 
     default:
       return state

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",

--- a/packages/shift-react-components/src/components/navigation/navbar.js
+++ b/packages/shift-react-components/src/components/navigation/navbar.js
@@ -1,6 +1,10 @@
 // Libraries
 import React, { Component } from 'react'
 import t from 'typy'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+
+import isEqual from 'lodash/isEqual'
 
 // Components
 import { Image } from '../../objects/image'
@@ -78,6 +82,10 @@ export class NavBar extends Component {
     )
   }
 
+  shouldComponentUpdate (nextProps) {
+    return !isEqual(this.props.menu, nextProps.menu)
+  }
+
   render () {
     const { loading, error } = this.props.menu
     const menuItems = t(this.props, 'menu[0].menu_items').safeObject
@@ -100,4 +108,8 @@ export class NavBar extends Component {
       )
     }
   }
+}
+
+NavBar.propTypes = {
+  menu: PropTypes.object.isRequired
 }


### PR DESCRIPTION
## Description

We now will only request the menu if it has not been loaded.  Server side requests will make the request to the platform for the menu data and then populate the redux store.  If that hasn't happened, for any reason (menu wasn't included/needed in the SSR) then it'll happen client side.  

It also prevents any unnecessary rerenders from happening client-side through use of shouldComponentUpdate()

## Related Issue

@shiftcommerce/trendy-golf#131

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [ ] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

Verified this works by loading trendy and reference site using this code and everything works fine, and no client side getMenu calls are made.


### Dependencies Review
None