### PR TITLE
OMS Fixes - Shift React Components updates

### DIFF
--- a/packages/reference/cypress/integration/account/order-history.js
+++ b/packages/reference/cypress/integration/account/order-history.js
@@ -53,16 +53,16 @@ describe('My Account', () => {
       cy.wait('@getCustomerOrders')
 
       // Check that the data returned is rendered in a list
-      cy.get('.c-order-history__header').should('have.length', 5)
+      cy.get('.c-order-history-table__row--body').should('have.length', 5)
 
       // Expand the first order in the list
-      cy.get('.c-order-history__header').first().click()
+      cy.get('.c-order-history-table__row--body a').first().click()
 
       // Expect first order to contain values
       cy.contains(/H2155-88-small/i)
-      cy.contains(/quantity: 2/i)
-      cy.contains(/delivery: Demo UK Delivery/i)
-      cy.contains(/address: test customer/i)
+      cy.contains(/quantity2/i)
+      cy.contains(/shipping methodDemo UK Delivery/i)
+      cy.contains(/shipping addresstest customer/i)
       cy.contains(/£219.90/i)
     })
   })

--- a/packages/shift-next/src/pages/account/orders.js
+++ b/packages/shift-next/src/pages/account/orders.js
@@ -8,17 +8,38 @@ import { AccountOrders } from '@shiftcommerce/shift-react-components/src/compone
 import { getCustomerOrders } from '../../actions/account-actions'
 
 export class AccountOrdersPage extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      currentOrderRef: null
+    }
+
+    this.updateCurrentOrder = this.updateCurrentOrder.bind(this)
+  }
+
+  updateCurrentOrder (event, currentOrderRef = null) {
+    event.preventDefault()
+    this.setState({ currentOrderRef })
+  }
+
   fetchOrders () {
     this.props.dispatch(getCustomerOrders())
   }
 
   render () {
     const { layout, orders } = this.props
+    const { currentOrderRef } = this.state
     const Layout = layout.component
 
     return (
       <Layout {...layout.props}>
-        <AccountOrders orders={orders} fetchOrders={this.fetchOrders.bind(this)} />
+        <AccountOrders
+          currentOrderRef={currentOrderRef}
+          fetchOrders={this.fetchOrders.bind(this)}
+          orders={orders}
+          updateCurrentOrder={this.updateCurrentOrder}
+        />
       </Layout>
     )
   }

--- a/packages/shift-react-components/__tests__/components/cart/__snapshots__/line-items.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/cart/__snapshots__/line-items.spec.js.snap
@@ -156,20 +156,6 @@ exports[`renders line item quantity if updateQuantity function is not provided 1
               </span>
             </div>
           </div>
-          <div
-            className="c-line-items__remove"
-          >
-            <div
-              className="c-line-items__delete"
-            >
-              <a
-                className="c-line-items__delete-button"
-                data-id="311"
-              >
-                Delete
-              </a>
-            </div>
-          </div>
         </div>
         <div
           className="c-line-items__quantity"
@@ -370,20 +356,6 @@ exports[`renders line items correctly, on initial load 1`] = `
               <span>
                 3008557600817
               </span>
-            </div>
-          </div>
-          <div
-            className="c-line-items__remove"
-          >
-            <div
-              className="c-line-items__delete"
-            >
-              <a
-                className="c-line-items__delete-button"
-                data-id="311"
-              >
-                Delete
-              </a>
             </div>
           </div>
         </div>
@@ -815,20 +787,6 @@ exports[`trigger updateQuantity function, on change of line item quantity 1`] = 
               <span>
                 3008557600817
               </span>
-            </div>
-          </div>
-          <div
-            className="c-line-items__remove"
-          >
-            <div
-              className="c-line-items__delete"
-            >
-              <a
-                className="c-line-items__delete-button"
-                data-id="311"
-              >
-                Delete
-              </a>
             </div>
           </div>
         </div>

--- a/packages/shift-react-components/__tests__/components/checkout/__snapshots__/checkout-cart.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/checkout/__snapshots__/checkout-cart.spec.js.snap
@@ -221,19 +221,6 @@ exports[`Checkout Cart renders the correct cart summary with multiple line items
                 <span />
               </div>
             </div>
-            <div
-              className="c-line-items__remove"
-            >
-              <div
-                className="c-line-items__delete"
-              >
-                <a
-                  className="c-line-items__delete-button"
-                >
-                  Delete
-                </a>
-              </div>
-            </div>
           </div>
           <div
             className="c-line-items__quantity"
@@ -303,19 +290,6 @@ exports[`Checkout Cart renders the correct cart summary with multiple line items
                 className="c-line-items__details-sku"
               >
                 <span />
-              </div>
-            </div>
-            <div
-              className="c-line-items__remove"
-            >
-              <div
-                className="c-line-items__delete"
-              >
-                <a
-                  className="c-line-items__delete-button"
-                >
-                  Delete
-                </a>
               </div>
             </div>
           </div>
@@ -537,19 +511,6 @@ exports[`Checkout Cart renders the correct cart summary with single line item 1`
                 className="c-line-items__details-sku"
               >
                 <span />
-              </div>
-            </div>
-            <div
-              className="c-line-items__remove"
-            >
-              <div
-                className="c-line-items__delete"
-              >
-                <a
-                  className="c-line-items__delete-button"
-                >
-                  Delete
-                </a>
               </div>
             </div>
           </div>

--- a/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-list.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-list.spec.js.snap
@@ -535,1013 +535,133 @@ exports[`renders correctly 1`] = `
   }
 >
   <div
-    className="c-order-history__header"
-    key="61c40964-4b4c-4f54-b580-958798087312"
+    className="c-order-history-table"
   >
-    <h4>
-      Jan 1, 2018
-       - 
-      1000
-       - £
-      1506.00
-    </h4>
-    <label
-      className="c-order-history__header-label"
-      htmlFor="1000"
-    />
-    <input
-      id="1000"
-      type="checkbox"
-    />
-    <span
-      className="c-order-history__arrow"
-    />
     <div
-      className="c-order-history__details"
+      className="c-order-history-table__row c-order-history-table__row--header"
     >
       <div
-        className="c-order-history__order-summary"
+        className="c-order-history-table__col c-order-history-table__col--header"
+        key="0"
       >
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Date of Order: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            Jan 1, 2018
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Items: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            3
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Order Number: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            1000
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Total: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            £
-            1506.00
-          </a>
-        </div>
+        Order No.
       </div>
-      <OrderLineItems
-        items={
-          Array [
-            Object {
-              "discounts": Array [],
-              "id": "61c40964-4b4c-4f54-b580-958798087312_0",
-              "image_urls": Array [
-                "https://example.com/path/to/image.jpg",
-                "https://example.com/path/to/image1.jpg",
-              ],
-              "individual_prices": Array [],
-              "pricing": Object {
-                "each_ex_tax": 1200,
-                "each_inc_tax": 1440,
-                "line_discount_ex_tax": 0,
-                "line_discount_inc_tax": 0,
-                "line_ex_tax": 6000,
-                "line_total_inc_tax": 7200,
-                "tax_rate": 12000,
-              },
-              "quantity": 5,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": "SHIFT Commerce",
-                "country": "United Kingdom",
-                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-                "lines": Array [
-                  "The Calls",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-                "label": "Next Day Delivery",
-                "meta_attributes": Object {
-                  "sku": "NEXTDAY",
-                },
-                "price": 599,
-              },
-              "sku": "WHITE-TSHIRT-XXL",
-            },
-            Object {
-              "discounts": Array [
-                Object {
-                  "amount_ex_tax": 200,
-                  "amount_inc_tax": 240,
-                  "coupon_code": "3FOR2SOCKS",
-                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_0",
-                  "label": "3 for 2 on Socks",
-                  "meta_attributes": Object {},
-                },
-              ],
-              "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-              "image_urls": Array [],
-              "individual_prices": Array [
-                Object {
-                  "discount_ex_tax": 67,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 67,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "61c40964-4b4c-4f54-b580-958798087312_1_0_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 133,
-                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_0",
-                  "inc_tax": 160,
-                },
-                Object {
-                  "discount_ex_tax": 67,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 67,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "61c40964-4b4c-4f54-b580-958798087312_1_1_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 133,
-                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_1",
-                  "inc_tax": 160,
-                },
-                Object {
-                  "discount_ex_tax": 66,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 66,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "61c40964-4b4c-4f54-b580-958798087312_1_2_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 134,
-                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_2",
-                  "inc_tax": 160,
-                },
-              ],
-              "pricing": Object {
-                "each_ex_tax": 200,
-                "each_inc_tax": 240,
-                "line_discount_ex_tax": 200,
-                "line_discount_inc_tax": 240,
-                "line_ex_tax": 400,
-                "line_total_inc_tax": 480,
-                "tax_rate": 12000,
-              },
-              "quantity": 3,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": null,
-                "country": "United Kingdom",
-                "id": "61c40964-4b4c-4f54-b580-958798087312_2",
-                "lines": Array [
-                  "SHIFT Commerce",
-                  "The Calls Landing",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer 2",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "61c40964-4b4c-4f54-b580-958798087312_2",
-                "label": "Two-man Delivery",
-                "meta_attributes": Object {
-                  "sku": "DROPSHIP",
-                },
-                "price": 2499,
-              },
-              "sku": "BLACK-SOCKS-001",
-            },
-            Object {
-              "discounts": Array [],
-              "id": "61c40964-4b4c-4f54-b580-958798087312_2",
-              "image_urls": Array [],
-              "individual_prices": Array [],
-              "pricing": Object {
-                "each_ex_tax": 120000,
-                "each_inc_tax": 144000,
-                "line_discount_ex_tax": 0,
-                "line_discount_inc_tax": 0,
-                "line_ex_tax": 120000,
-                "line_total_inc_tax": 144000,
-                "tax_rate": 12000,
-              },
-              "quantity": 1,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": "SHIFT Commerce",
-                "country": "United Kingdom",
-                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-                "lines": Array [
-                  "The Calls",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-                "label": "Next Day Delivery",
-                "meta_attributes": Object {
-                  "sku": "NEXTDAY",
-                },
-                "price": 599,
-              },
-              "sku": "WHITE-TSHIRT-L",
-            },
-          ]
-        }
-      >
-        <div
-          className="c-order-history__line-items_grid"
-          key="WHITE-TSHIRT-XXL"
-        >
-          <img
-            src="https://example.com/path/to/image.jpg"
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              WHITE-TSHIRT-XXL
-            </h5>
-            <h4>
-              WHITE-TSHIRT-XXL
-            </h4>
-            <span>
-              Quantity: 
-              5
-            </span>
-            <span>
-              Delivery: 
-              Next Day Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              72.00
-            </a>
-          </div>
-        </div>
-        <div
-          className="c-order-history__line-items_grid"
-          key="BLACK-SOCKS-001"
-        >
-          <img
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              BLACK-SOCKS-001
-            </h5>
-            <h4>
-              BLACK-SOCKS-001
-            </h4>
-            <span>
-              Quantity: 
-              3
-            </span>
-            <span>
-              Delivery: 
-              Two-man Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer 2
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              4.80
-            </a>
-          </div>
-        </div>
-        <div
-          className="c-order-history__line-items_grid"
-          key="WHITE-TSHIRT-L"
-        >
-          <img
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              WHITE-TSHIRT-L
-            </h5>
-            <h4>
-              WHITE-TSHIRT-L
-            </h4>
-            <span>
-              Quantity: 
-              1
-            </span>
-            <span>
-              Delivery: 
-              Next Day Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              1440.00
-            </a>
-          </div>
-        </div>
-      </OrderLineItems>
       <div
-        className="c-order-history__totals"
+        className="c-order-history-table__col c-order-history-table__col--header"
+        key="1"
       >
-        <p>
-          Shipping: £
-          30.98
-           
-        </p>
-        <p
-          className="u-bold"
-        >
-          Total: £
-          1506.00
-        </p>
+        Order Date
       </div>
-      <h3>
-        Shipping Details
-      </h3>
-      <ShippingAddresses
-        addresses={
-          Array [
-            Object {
-              "city": "Leeds",
-              "company": "SHIFT Commerce",
-              "country": "United Kingdom",
-              "id": "61c40964-4b4c-4f54-b580-958798087312_1",
-              "lines": Array [
-                "The Calls",
-              ],
-              "meta_attributes": Object {
-                "further": "information",
-              },
-              "name": "Test Customer",
-              "postcode": "LS2 7EY",
-              "state": "West Yorkshire",
-            },
-            Object {
-              "city": "Leeds",
-              "company": null,
-              "country": "United Kingdom",
-              "id": "61c40964-4b4c-4f54-b580-958798087312_2",
-              "lines": Array [
-                "SHIFT Commerce",
-                "The Calls Landing",
-              ],
-              "meta_attributes": Object {
-                "further": "information",
-              },
-              "name": "Test Customer 2",
-              "postcode": "LS2 7EY",
-              "state": "West Yorkshire",
-            },
-          ]
-        }
+      <div
+        className="c-order-history-table__col c-order-history-table__col--header"
+        key="2"
       >
-        <div
-          className="c-order-history__shipping-address"
-          key="61c40964-4b4c-4f54-b580-958798087312_1"
-        >
-          <p
-            className="u-bold"
-          >
-            Test Customer
-          </p>
-          <p>
-            SHIFT Commerce
-          </p>
-          <p>
-            The Calls
-          </p>
-          <p>
-            Leeds
-          </p>
-          <p>
-            West Yorkshire
-          </p>
-          <p>
-            LS2 7EY
-          </p>
-          <p>
-            United Kingdom
-          </p>
-        </div>
-        <div
-          className="c-order-history__shipping-address"
-          key="61c40964-4b4c-4f54-b580-958798087312_2"
-        >
-          <p
-            className="u-bold"
-          >
-            Test Customer 2
-          </p>
-          <p />
-          <p>
-            SHIFT Commerce,The Calls Landing
-          </p>
-          <p>
-            Leeds
-          </p>
-          <p>
-            West Yorkshire
-          </p>
-          <p>
-            LS2 7EY
-          </p>
-          <p>
-            United Kingdom
-          </p>
-        </div>
-      </ShippingAddresses>
+        Cost
+      </div>
+      <div
+        className="c-order-history-table__col c-order-history-table__col--header"
+        key="3"
+      />
     </div>
-  </div>
-  <div
-    className="c-order-history__header"
-    key="fda3fcff-92c7-414a-bdea-156cde21a926"
-  >
-    <h4>
-      Jan 1, 2018
-       - 
-      1001
-       - £
-      1606.00
-    </h4>
-    <label
-      className="c-order-history__header-label"
-      htmlFor="1001"
-    />
-    <input
-      id="1001"
-      type="checkbox"
-    />
-    <span
-      className="c-order-history__arrow"
-    />
     <div
-      className="c-order-history__details"
+      className="c-order-history-table__row c-order-history-table__row--body"
+      key="61c40964-4b4c-4f54-b580-958798087312"
     >
       <div
-        className="c-order-history__order-summary"
+        className="c-order-history-table__col"
+        key="0"
       >
-        <div
-          className="c-order-history__order-summary_params"
+        <span
+          className="c-order-history-table__label"
         >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Date of Order: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            Jan 1, 2018
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Items: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            3
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Order Number: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            1001
-          </a>
-        </div>
-        <div
-          className="c-order-history__order-summary_params"
-        >
-          <p
-            className="u-bold u-inline-block"
-          >
-            Total: 
-          </p>
-          <a
-            className="u-inline-block"
-          >
-            £
-            1606.00
-          </a>
-        </div>
+          Order No.
+        </span>
+        1000
       </div>
-      <OrderLineItems
-        items={
-          Array [
-            Object {
-              "discounts": Array [],
-              "id": "fda3fcff-92c7-414a-bdea-156cde21a926_0",
-              "image_urls": Array [
-                "https://example.com/path/to/image.jpg",
-                "https://example.com/path/to/image1.jpg",
-              ],
-              "individual_prices": Array [],
-              "pricing": Object {
-                "each_ex_tax": 1200,
-                "each_inc_tax": 1440,
-                "line_discount_ex_tax": 0,
-                "line_discount_inc_tax": 0,
-                "line_ex_tax": 6000,
-                "line_total_inc_tax": 7200,
-                "tax_rate": 12000,
-              },
-              "quantity": 5,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": "SHIFT Commerce",
-                "country": "United Kingdom",
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-                "lines": Array [
-                  "The Calls",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-                "label": "Next Day Delivery",
-                "meta_attributes": Object {
-                  "sku": "NEXTDAY",
-                },
-                "price": 599,
-              },
-              "sku": "WHITE-TSHIRT-XXL",
-            },
-            Object {
-              "discounts": Array [
-                Object {
-                  "amount_ex_tax": 200,
-                  "amount_inc_tax": 240,
-                  "coupon_code": "3FOR2SOCKS",
-                  "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_0",
-                  "label": "3 for 2 on Socks",
-                  "meta_attributes": Object {},
-                },
-              ],
-              "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-              "image_urls": Array [],
-              "individual_prices": Array [
-                Object {
-                  "discount_ex_tax": 67,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 67,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_0_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 133,
-                  "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_0",
-                  "inc_tax": 160,
-                },
-                Object {
-                  "discount_ex_tax": 67,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 67,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_1_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 133,
-                  "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_1",
-                  "inc_tax": 160,
-                },
-                Object {
-                  "discount_ex_tax": 66,
-                  "discount_inc_tax": 80,
-                  "discounts": Array [
-                    Object {
-                      "amount_ex_tax": 66,
-                      "amount_inc_tax": 80,
-                      "coupon_code": null,
-                      "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_2_0",
-                      "label": "3 for 2 on Socks",
-                      "meta_attributes": Object {},
-                    },
-                  ],
-                  "ex_tax": 134,
-                  "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1_2",
-                  "inc_tax": 160,
-                },
-              ],
-              "pricing": Object {
-                "each_ex_tax": 200,
-                "each_inc_tax": 240,
-                "line_discount_ex_tax": 200,
-                "line_discount_inc_tax": 240,
-                "line_ex_tax": 400,
-                "line_total_inc_tax": 480,
-                "tax_rate": 12000,
-              },
-              "quantity": 3,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": null,
-                "country": "United Kingdom",
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_2",
-                "lines": Array [
-                  "SHIFT Commerce",
-                  "The Calls Landing",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer 2",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_2",
-                "label": "Two-man Delivery",
-                "meta_attributes": Object {
-                  "sku": "DROPSHIP",
-                },
-                "price": 2499,
-              },
-              "sku": "BLACK-SOCKS-001",
-            },
-            Object {
-              "discounts": Array [],
-              "id": "fda3fcff-92c7-414a-bdea-156cde21a926_2",
-              "image_urls": Array [],
-              "individual_prices": Array [],
-              "pricing": Object {
-                "each_ex_tax": 120000,
-                "each_inc_tax": 144000,
-                "line_discount_ex_tax": 0,
-                "line_discount_inc_tax": 0,
-                "line_ex_tax": 120000,
-                "line_total_inc_tax": 144000,
-                "tax_rate": 12000,
-              },
-              "quantity": 1,
-              "shipping_address": Object {
-                "city": "Leeds",
-                "company": "SHIFT Commerce",
-                "country": "United Kingdom",
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-                "lines": Array [
-                  "The Calls",
-                ],
-                "meta_attributes": Object {
-                  "further": "information",
-                },
-                "name": "Test Customer",
-                "postcode": "LS2 7EY",
-                "state": "West Yorkshire",
-              },
-              "shipping_method": Object {
-                "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-                "label": "Next Day Delivery",
-                "meta_attributes": Object {
-                  "sku": "NEXTDAY",
-                },
-                "price": 599,
-              },
-              "sku": "WHITE-TSHIRT-L",
-            },
-          ]
-        }
-      >
-        <div
-          className="c-order-history__line-items_grid"
-          key="WHITE-TSHIRT-XXL"
-        >
-          <img
-            src="https://example.com/path/to/image.jpg"
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              WHITE-TSHIRT-XXL
-            </h5>
-            <h4>
-              WHITE-TSHIRT-XXL
-            </h4>
-            <span>
-              Quantity: 
-              5
-            </span>
-            <span>
-              Delivery: 
-              Next Day Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              72.00
-            </a>
-          </div>
-        </div>
-        <div
-          className="c-order-history__line-items_grid"
-          key="BLACK-SOCKS-001"
-        >
-          <img
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              BLACK-SOCKS-001
-            </h5>
-            <h4>
-              BLACK-SOCKS-001
-            </h4>
-            <span>
-              Quantity: 
-              3
-            </span>
-            <span>
-              Delivery: 
-              Two-man Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer 2
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              4.80
-            </a>
-          </div>
-        </div>
-        <div
-          className="c-order-history__line-items_grid"
-          key="WHITE-TSHIRT-L"
-        >
-          <img
-            width={300}
-          />
-          <div
-            className="c-order-history__line-items_grid_item1"
-          >
-            <h5>
-              WHITE-TSHIRT-L
-            </h5>
-            <h4>
-              WHITE-TSHIRT-L
-            </h4>
-            <span>
-              Quantity: 
-              1
-            </span>
-            <span>
-              Delivery: 
-              Next Day Delivery
-            </span>
-            <span>
-              Address: 
-              Test Customer
-            </span>
-          </div>
-          <div
-            className="c-order-history__line-items_grid_item2"
-          >
-            <a>
-              £
-              1440.00
-            </a>
-          </div>
-        </div>
-      </OrderLineItems>
       <div
-        className="c-order-history__totals"
+        className="c-order-history-table__col"
+        key="1"
       >
-        <p>
-          Shipping: £
-          30.98
-           
-        </p>
-        <p
-          className="u-bold"
+        <span
+          className="c-order-history-table__label"
         >
-          Total: £
-          1606.00
-        </p>
+          Order Date
+        </span>
+        Jan 1, 2018
       </div>
-      <h3>
-        Shipping Details
-      </h3>
-      <ShippingAddresses
-        addresses={
-          Array [
-            Object {
-              "city": "Leeds",
-              "company": "SHIFT Commerce",
-              "country": "United Kingdom",
-              "id": "fda3fcff-92c7-414a-bdea-156cde21a926_1",
-              "lines": Array [
-                "The Calls",
-              ],
-              "meta_attributes": Object {
-                "further": "information",
-              },
-              "name": "Test Customer",
-              "postcode": "LS2 7EY",
-              "state": "West Yorkshire",
-            },
-            Object {
-              "city": "Leeds",
-              "company": null,
-              "country": "United Kingdom",
-              "id": "fda3fcff-92c7-414a-bdea-156cde21a926_2",
-              "lines": Array [
-                "SHIFT Commerce",
-                "The Calls Landing",
-              ],
-              "meta_attributes": Object {
-                "further": "information",
-              },
-              "name": "Test Customer 2",
-              "postcode": "LS2 7EY",
-              "state": "West Yorkshire",
-            },
-          ]
-        }
+      <div
+        className="c-order-history-table__col"
+        key="2"
       >
-        <div
-          className="c-order-history__shipping-address"
-          key="fda3fcff-92c7-414a-bdea-156cde21a926_1"
+        <span
+          className="c-order-history-table__label"
         >
-          <p
-            className="u-bold"
-          >
-            Test Customer
-          </p>
-          <p>
-            SHIFT Commerce
-          </p>
-          <p>
-            The Calls
-          </p>
-          <p>
-            Leeds
-          </p>
-          <p>
-            West Yorkshire
-          </p>
-          <p>
-            LS2 7EY
-          </p>
-          <p>
-            United Kingdom
-          </p>
-        </div>
-        <div
-          className="c-order-history__shipping-address"
-          key="fda3fcff-92c7-414a-bdea-156cde21a926_2"
+          Cost
+        </span>
+        1506.00
+      </div>
+      <div
+        className="c-order-history-table__col"
+        key="3"
+      >
+        <a
+          className="o-button o-button--primary"
+          href="/account/orders/1000"
+          onClick={[Function]}
         >
-          <p
-            className="u-bold"
-          >
-            Test Customer 2
-          </p>
-          <p />
-          <p>
-            SHIFT Commerce,The Calls Landing
-          </p>
-          <p>
-            Leeds
-          </p>
-          <p>
-            West Yorkshire
-          </p>
-          <p>
-            LS2 7EY
-          </p>
-          <p>
-            United Kingdom
-          </p>
-        </div>
-      </ShippingAddresses>
+          View Details
+        </a>
+      </div>
+    </div>
+    <div
+      className="c-order-history-table__row c-order-history-table__row--body"
+      key="fda3fcff-92c7-414a-bdea-156cde21a926"
+    >
+      <div
+        className="c-order-history-table__col"
+        key="0"
+      >
+        <span
+          className="c-order-history-table__label"
+        >
+          Order No.
+        </span>
+        1001
+      </div>
+      <div
+        className="c-order-history-table__col"
+        key="1"
+      >
+        <span
+          className="c-order-history-table__label"
+        >
+          Order Date
+        </span>
+        Jan 1, 2018
+      </div>
+      <div
+        className="c-order-history-table__col"
+        key="2"
+      >
+        <span
+          className="c-order-history-table__label"
+        >
+          Cost
+        </span>
+        1606.00
+      </div>
+      <div
+        className="c-order-history-table__col"
+        key="3"
+      >
+        <a
+          className="o-button o-button--primary"
+          href="/account/orders/1001"
+          onClick={[Function]}
+        >
+          View Details
+        </a>
+      </div>
     </div>
   </div>
 </OrderList>

--- a/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-single.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-single.spec.js.snap
@@ -592,7 +592,7 @@ exports[`renders correctly 1`] = `
                         "title": "product title",
                       },
                       "sku": "WHITE-TSHIRT-XXL",
-                      "title": "item title",
+                      "title": "WHITE-TSHIRT-XXL",
                     },
                     "sub_total": 72,
                     "total": 72,
@@ -607,7 +607,7 @@ exports[`renders correctly 1`] = `
                         "title": "product title",
                       },
                       "sku": "BLACK-SOCKS-001",
-                      "title": "item title",
+                      "title": "BLACK-SOCKS-001",
                     },
                     "sub_total": 4.8,
                     "total": 4.8,
@@ -622,7 +622,7 @@ exports[`renders correctly 1`] = `
                         "title": "product title",
                       },
                       "sku": "WHITE-TSHIRT-L",
-                      "title": "item title",
+                      "title": "WHITE-TSHIRT-L",
                     },
                     "sub_total": 1440,
                     "total": 1440,
@@ -649,8 +649,8 @@ exports[`renders correctly 1`] = `
                         href="/slug?slug=undefined"
                       >
                         <Image
-                          alt="item title"
-                          aria-label="item title"
+                          alt="WHITE-TSHIRT-XXL"
+                          aria-label="WHITE-TSHIRT-XXL"
                           className="c-line-items__image"
                           key="slug"
                           src="https://example.com/path/to/image.jpg"
@@ -660,8 +660,8 @@ exports[`renders correctly 1`] = `
                           >
                             <picture>
                               <img
-                                alt="item title"
-                                aria-label="item title"
+                                alt="WHITE-TSHIRT-XXL"
+                                aria-label="WHITE-TSHIRT-XXL"
                                 className="o-image"
                                 src="https://example.com/path/to/image.jpg"
                                 srcSet="https://example.com/path/to/image.jpg 769w"
@@ -684,7 +684,7 @@ exports[`renders correctly 1`] = `
                         <h4
                           className="c-line-items__details-title u-bold"
                         >
-                          product title - item title
+                          product title - WHITE-TSHIRT-XXL
                         </h4>
                         <div
                           className="c-line-items__details-sku"
@@ -735,8 +735,8 @@ exports[`renders correctly 1`] = `
                         href="/slug?slug=undefined"
                       >
                         <Image
-                          alt="item title"
-                          aria-label="item title"
+                          alt="BLACK-SOCKS-001"
+                          aria-label="BLACK-SOCKS-001"
                           className="c-line-items__image"
                           key="slug"
                         />
@@ -755,7 +755,7 @@ exports[`renders correctly 1`] = `
                         <h4
                           className="c-line-items__details-title u-bold"
                         >
-                          product title - item title
+                          product title - BLACK-SOCKS-001
                         </h4>
                         <div
                           className="c-line-items__details-sku"
@@ -806,8 +806,8 @@ exports[`renders correctly 1`] = `
                         href="/slug?slug=undefined"
                       >
                         <Image
-                          alt="item title"
-                          aria-label="item title"
+                          alt="WHITE-TSHIRT-L"
+                          aria-label="WHITE-TSHIRT-L"
                           className="c-line-items__image"
                           key="slug"
                         />
@@ -826,7 +826,7 @@ exports[`renders correctly 1`] = `
                         <h4
                           className="c-line-items__details-title u-bold"
                         >
-                          product title - item title
+                          product title - WHITE-TSHIRT-L
                         </h4>
                         <div
                           className="c-line-items__details-sku"

--- a/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-single.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/orders/__snapshots__/order-single.spec.js.snap
@@ -1,0 +1,945 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<OrderSingle
+  order={
+    Object {
+      "account_reference": "shiftacc",
+      "customer": Object {
+        "email": "test@shiftcommerce.com",
+        "id": "61c40964-4b4c-4f54-b580-958798087312",
+        "meta_attributes": Object {},
+        "name": "SHIFT",
+        "reference": "23063301",
+      },
+      "id": "61c40964-4b4c-4f54-b580-958798087312",
+      "line_items": Array [
+        Object {
+          "discounts": Array [],
+          "id": "61c40964-4b4c-4f54-b580-958798087312_0",
+          "image_urls": Array [
+            "https://example.com/path/to/image.jpg",
+            "https://example.com/path/to/image1.jpg",
+          ],
+          "individual_prices": Array [],
+          "pricing": Object {
+            "each_ex_tax": 1200,
+            "each_inc_tax": 1440,
+            "line_discount_ex_tax": 0,
+            "line_discount_inc_tax": 0,
+            "line_ex_tax": 6000,
+            "line_total_inc_tax": 7200,
+            "tax_rate": 12000,
+          },
+          "quantity": 5,
+          "shipping_address": Object {
+            "city": "Leeds",
+            "company": "SHIFT Commerce",
+            "country": "United Kingdom",
+            "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+            "lines": Array [
+              "The Calls",
+            ],
+            "meta_attributes": Object {
+              "further": "information",
+            },
+            "name": "Test Customer",
+            "postcode": "LS2 7EY",
+            "state": "West Yorkshire",
+          },
+          "shipping_method": Object {
+            "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+            "label": "Next Day Delivery",
+            "meta_attributes": Object {
+              "sku": "NEXTDAY",
+            },
+            "price": 599,
+          },
+          "sku": "WHITE-TSHIRT-XXL",
+        },
+        Object {
+          "discounts": Array [
+            Object {
+              "amount_ex_tax": 200,
+              "amount_inc_tax": 240,
+              "coupon_code": "3FOR2SOCKS",
+              "id": "61c40964-4b4c-4f54-b580-958798087312_1_0",
+              "label": "3 for 2 on Socks",
+              "meta_attributes": Object {},
+            },
+          ],
+          "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+          "image_urls": Array [],
+          "individual_prices": Array [
+            Object {
+              "discount_ex_tax": 67,
+              "discount_inc_tax": 80,
+              "discounts": Array [
+                Object {
+                  "amount_ex_tax": 67,
+                  "amount_inc_tax": 80,
+                  "coupon_code": null,
+                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_0_0",
+                  "label": "3 for 2 on Socks",
+                  "meta_attributes": Object {},
+                },
+              ],
+              "ex_tax": 133,
+              "id": "61c40964-4b4c-4f54-b580-958798087312_1_0",
+              "inc_tax": 160,
+            },
+            Object {
+              "discount_ex_tax": 67,
+              "discount_inc_tax": 80,
+              "discounts": Array [
+                Object {
+                  "amount_ex_tax": 67,
+                  "amount_inc_tax": 80,
+                  "coupon_code": null,
+                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_1_0",
+                  "label": "3 for 2 on Socks",
+                  "meta_attributes": Object {},
+                },
+              ],
+              "ex_tax": 133,
+              "id": "61c40964-4b4c-4f54-b580-958798087312_1_1",
+              "inc_tax": 160,
+            },
+            Object {
+              "discount_ex_tax": 66,
+              "discount_inc_tax": 80,
+              "discounts": Array [
+                Object {
+                  "amount_ex_tax": 66,
+                  "amount_inc_tax": 80,
+                  "coupon_code": null,
+                  "id": "61c40964-4b4c-4f54-b580-958798087312_1_2_0",
+                  "label": "3 for 2 on Socks",
+                  "meta_attributes": Object {},
+                },
+              ],
+              "ex_tax": 134,
+              "id": "61c40964-4b4c-4f54-b580-958798087312_1_2",
+              "inc_tax": 160,
+            },
+          ],
+          "pricing": Object {
+            "each_ex_tax": 200,
+            "each_inc_tax": 240,
+            "line_discount_ex_tax": 200,
+            "line_discount_inc_tax": 240,
+            "line_ex_tax": 400,
+            "line_total_inc_tax": 480,
+            "tax_rate": 12000,
+          },
+          "quantity": 3,
+          "shipping_address": Object {
+            "city": "Leeds",
+            "company": null,
+            "country": "United Kingdom",
+            "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+            "lines": Array [
+              "SHIFT Commerce",
+              "The Calls Landing",
+            ],
+            "meta_attributes": Object {
+              "further": "information",
+            },
+            "name": "Test Customer 2",
+            "postcode": "LS2 7EY",
+            "state": "West Yorkshire",
+          },
+          "shipping_method": Object {
+            "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+            "label": "Two-man Delivery",
+            "meta_attributes": Object {
+              "sku": "DROPSHIP",
+            },
+            "price": 2499,
+          },
+          "sku": "BLACK-SOCKS-001",
+        },
+        Object {
+          "discounts": Array [],
+          "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+          "image_urls": Array [],
+          "individual_prices": Array [],
+          "pricing": Object {
+            "each_ex_tax": 120000,
+            "each_inc_tax": 144000,
+            "line_discount_ex_tax": 0,
+            "line_discount_inc_tax": 0,
+            "line_ex_tax": 120000,
+            "line_total_inc_tax": 144000,
+            "tax_rate": 12000,
+          },
+          "quantity": 1,
+          "shipping_address": Object {
+            "city": "Leeds",
+            "company": "SHIFT Commerce",
+            "country": "United Kingdom",
+            "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+            "lines": Array [
+              "The Calls",
+            ],
+            "meta_attributes": Object {
+              "further": "information",
+            },
+            "name": "Test Customer",
+            "postcode": "LS2 7EY",
+            "state": "West Yorkshire",
+          },
+          "shipping_method": Object {
+            "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+            "label": "Next Day Delivery",
+            "meta_attributes": Object {
+              "sku": "NEXTDAY",
+            },
+            "price": 599,
+          },
+          "sku": "WHITE-TSHIRT-L",
+        },
+      ],
+      "placed_at": "2018-01-01T12:00:00.000Z",
+      "pricing": Object {
+        "currency": "GBP",
+        "pre_discount_total_ex_tax": 126600,
+        "pre_discount_total_inc_tax": 151440,
+        "total_discount_ex_tax": 700,
+        "total_discount_inc_tax": 840,
+        "total_ex_tax": 125900,
+        "total_inc_tax": 150600,
+      },
+      "reference": "1000",
+      "shipping_addresses": Array [
+        Object {
+          "city": "Leeds",
+          "company": "SHIFT Commerce",
+          "country": "United Kingdom",
+          "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+          "lines": Array [
+            "The Calls",
+          ],
+          "meta_attributes": Object {
+            "further": "information",
+          },
+          "name": "Test Customer",
+          "postcode": "LS2 7EY",
+          "state": "West Yorkshire",
+        },
+        Object {
+          "city": "Leeds",
+          "company": null,
+          "country": "United Kingdom",
+          "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+          "lines": Array [
+            "SHIFT Commerce",
+            "The Calls Landing",
+          ],
+          "meta_attributes": Object {
+            "further": "information",
+          },
+          "name": "Test Customer 2",
+          "postcode": "LS2 7EY",
+          "state": "West Yorkshire",
+        },
+      ],
+      "shipping_methods": Array [
+        Object {
+          "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+          "label": "Next Day Delivery",
+          "meta_attributes": Object {
+            "sku": "NEXTDAY",
+          },
+          "price": 599,
+        },
+        Object {
+          "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+          "label": "Two-man Delivery",
+          "meta_attributes": Object {
+            "sku": "DROPSHIP",
+          },
+          "price": 2499,
+        },
+      ],
+    }
+  }
+>
+  <div
+    className="c-order-history__nav"
+  >
+    <h2>
+      Order 
+      1000
+    </h2>
+  </div>
+  <div
+    className="c-order-single"
+  >
+    <div
+      className="c-order-single__item"
+      key="0"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Order No.
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        1000
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="1"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Order Date
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        Jan 1, 2018
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="2"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Cost
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        £1506.00
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="3"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Shipping Method
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        Next Day Delivery
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="4"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Billing Address
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        <ShippingAddresses
+          addresses={
+            Array [
+              Object {
+                "city": "Leeds",
+                "company": "SHIFT Commerce",
+                "country": "United Kingdom",
+                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+                "lines": Array [
+                  "The Calls",
+                ],
+                "meta_attributes": Object {
+                  "further": "information",
+                },
+                "name": "Test Customer",
+                "postcode": "LS2 7EY",
+                "state": "West Yorkshire",
+              },
+              Object {
+                "city": "Leeds",
+                "company": null,
+                "country": "United Kingdom",
+                "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+                "lines": Array [
+                  "SHIFT Commerce",
+                  "The Calls Landing",
+                ],
+                "meta_attributes": Object {
+                  "further": "information",
+                },
+                "name": "Test Customer 2",
+                "postcode": "LS2 7EY",
+                "state": "West Yorkshire",
+              },
+            ]
+          }
+        >
+          <div
+            className="c-order-history__shipping-address"
+            key="61c40964-4b4c-4f54-b580-958798087312_1"
+          >
+            <p
+              className="u-bold"
+            >
+              Test Customer
+            </p>
+            <p>
+              SHIFT Commerce
+            </p>
+            <p>
+              The Calls
+            </p>
+            <p>
+              Leeds
+            </p>
+            <p>
+              West Yorkshire
+            </p>
+            <p>
+              LS2 7EY
+            </p>
+            <p>
+              United Kingdom
+            </p>
+          </div>
+          <div
+            className="c-order-history__shipping-address"
+            key="61c40964-4b4c-4f54-b580-958798087312_2"
+          >
+            <p
+              className="u-bold"
+            >
+              Test Customer 2
+            </p>
+            <p />
+            <p>
+              SHIFT Commerce,The Calls Landing
+            </p>
+            <p>
+              Leeds
+            </p>
+            <p>
+              West Yorkshire
+            </p>
+            <p>
+              LS2 7EY
+            </p>
+            <p>
+              United Kingdom
+            </p>
+          </div>
+        </ShippingAddresses>
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="5"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Shipping Address
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        <ShippingAddresses
+          addresses={
+            Array [
+              Object {
+                "city": "Leeds",
+                "company": "SHIFT Commerce",
+                "country": "United Kingdom",
+                "id": "61c40964-4b4c-4f54-b580-958798087312_1",
+                "lines": Array [
+                  "The Calls",
+                ],
+                "meta_attributes": Object {
+                  "further": "information",
+                },
+                "name": "Test Customer",
+                "postcode": "LS2 7EY",
+                "state": "West Yorkshire",
+              },
+              Object {
+                "city": "Leeds",
+                "company": null,
+                "country": "United Kingdom",
+                "id": "61c40964-4b4c-4f54-b580-958798087312_2",
+                "lines": Array [
+                  "SHIFT Commerce",
+                  "The Calls Landing",
+                ],
+                "meta_attributes": Object {
+                  "further": "information",
+                },
+                "name": "Test Customer 2",
+                "postcode": "LS2 7EY",
+                "state": "West Yorkshire",
+              },
+            ]
+          }
+        >
+          <div
+            className="c-order-history__shipping-address"
+            key="61c40964-4b4c-4f54-b580-958798087312_1"
+          >
+            <p
+              className="u-bold"
+            >
+              Test Customer
+            </p>
+            <p>
+              SHIFT Commerce
+            </p>
+            <p>
+              The Calls
+            </p>
+            <p>
+              Leeds
+            </p>
+            <p>
+              West Yorkshire
+            </p>
+            <p>
+              LS2 7EY
+            </p>
+            <p>
+              United Kingdom
+            </p>
+          </div>
+          <div
+            className="c-order-history__shipping-address"
+            key="61c40964-4b4c-4f54-b580-958798087312_2"
+          >
+            <p
+              className="u-bold"
+            >
+              Test Customer 2
+            </p>
+            <p />
+            <p>
+              SHIFT Commerce,The Calls Landing
+            </p>
+            <p>
+              Leeds
+            </p>
+            <p>
+              West Yorkshire
+            </p>
+            <p>
+              LS2 7EY
+            </p>
+            <p>
+              United Kingdom
+            </p>
+          </div>
+        </ShippingAddresses>
+      </div>
+    </div>
+    <div
+      className="c-order-single__item"
+      key="6"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Currency
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        GBP
+      </div>
+    </div>
+    <div
+      className="c-order-single__item c-order-single__item--full"
+    >
+      <h5
+        className="c-order-single__header"
+      >
+        Order Summary
+      </h5>
+      <div
+        className="c-order-single__body"
+      >
+        <div
+          className="o-grid-container"
+        >
+          <div
+            className="o-col-1-7"
+          >
+            <LineItems
+              lineItems={
+                Array [
+                  Object {
+                    "id": 0,
+                    "item": Object {
+                      "picture_url": "https://example.com/path/to/image.jpg",
+                      "product": Object {
+                        "slug": "slug",
+                        "title": "product title",
+                      },
+                      "sku": "WHITE-TSHIRT-XXL",
+                      "title": "item title",
+                    },
+                    "sub_total": 72,
+                    "total": 72,
+                    "unit_quantity": 5,
+                  },
+                  Object {
+                    "id": 1,
+                    "item": Object {
+                      "picture_url": undefined,
+                      "product": Object {
+                        "slug": "slug",
+                        "title": "product title",
+                      },
+                      "sku": "BLACK-SOCKS-001",
+                      "title": "item title",
+                    },
+                    "sub_total": 4.8,
+                    "total": 4.8,
+                    "unit_quantity": 3,
+                  },
+                  Object {
+                    "id": 2,
+                    "item": Object {
+                      "picture_url": undefined,
+                      "product": Object {
+                        "slug": "slug",
+                        "title": "product title",
+                      },
+                      "sku": "WHITE-TSHIRT-L",
+                      "title": "item title",
+                    },
+                    "sub_total": 1440,
+                    "total": 1440,
+                    "unit_quantity": 1,
+                  },
+                ]
+              }
+              lineItemsCount={3}
+            >
+              <div
+                className="c-line-items"
+              >
+                <div
+                  className="c-line-items__sections"
+                  key="WHITE-TSHIRT-XXL"
+                >
+                  <div
+                    className="c-line-items__images"
+                  >
+                    <Link
+                      href="/slug?slug=undefined"
+                    >
+                      <a
+                        href="/slug?slug=undefined"
+                      >
+                        <Image
+                          alt="item title"
+                          aria-label="item title"
+                          className="c-line-items__image"
+                          key="slug"
+                          src="https://example.com/path/to/image.jpg"
+                        >
+                          <div
+                            className="c-line-items__image"
+                          >
+                            <picture>
+                              <img
+                                alt="item title"
+                                aria-label="item title"
+                                className="o-image"
+                                src="https://example.com/path/to/image.jpg"
+                                srcSet="https://example.com/path/to/image.jpg 769w"
+                              />
+                            </picture>
+                          </div>
+                        </Image>
+                      </a>
+                    </Link>
+                  </div>
+                  <div
+                    className="c-line-items__information"
+                  >
+                    <div
+                      className="c-line-items__title"
+                    >
+                      <div
+                        className="c-line-items__details"
+                      >
+                        <h4
+                          className="c-line-items__details-title u-bold"
+                        >
+                          product title - item title
+                        </h4>
+                        <div
+                          className="c-line-items__details-sku"
+                        >
+                          <span />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="c-line-items__quantity"
+                    >
+                      <div
+                        className="c-line-items__quantity-header"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </div>
+                      <span
+                        className="c-line-items__quantity-amount"
+                      >
+                        5
+                      </span>
+                    </div>
+                    <div
+                      className="c-line-items__amounts"
+                    >
+                      <a
+                        className="c-line-items__amount c-line-items__amount--total"
+                      >
+                        £
+                        72.00
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="c-line-items__sections"
+                  key="BLACK-SOCKS-001"
+                >
+                  <div
+                    className="c-line-items__images"
+                  >
+                    <Link
+                      href="/slug?slug=undefined"
+                    >
+                      <a
+                        href="/slug?slug=undefined"
+                      >
+                        <Image
+                          alt="item title"
+                          aria-label="item title"
+                          className="c-line-items__image"
+                          key="slug"
+                        />
+                      </a>
+                    </Link>
+                  </div>
+                  <div
+                    className="c-line-items__information"
+                  >
+                    <div
+                      className="c-line-items__title"
+                    >
+                      <div
+                        className="c-line-items__details"
+                      >
+                        <h4
+                          className="c-line-items__details-title u-bold"
+                        >
+                          product title - item title
+                        </h4>
+                        <div
+                          className="c-line-items__details-sku"
+                        >
+                          <span />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="c-line-items__quantity"
+                    >
+                      <div
+                        className="c-line-items__quantity-header"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </div>
+                      <span
+                        className="c-line-items__quantity-amount"
+                      >
+                        3
+                      </span>
+                    </div>
+                    <div
+                      className="c-line-items__amounts"
+                    >
+                      <a
+                        className="c-line-items__amount c-line-items__amount--total"
+                      >
+                        £
+                        4.80
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="c-line-items__sections"
+                  key="WHITE-TSHIRT-L"
+                >
+                  <div
+                    className="c-line-items__images"
+                  >
+                    <Link
+                      href="/slug?slug=undefined"
+                    >
+                      <a
+                        href="/slug?slug=undefined"
+                      >
+                        <Image
+                          alt="item title"
+                          aria-label="item title"
+                          className="c-line-items__image"
+                          key="slug"
+                        />
+                      </a>
+                    </Link>
+                  </div>
+                  <div
+                    className="c-line-items__information"
+                  >
+                    <div
+                      className="c-line-items__title"
+                    >
+                      <div
+                        className="c-line-items__details"
+                      >
+                        <h4
+                          className="c-line-items__details-title u-bold"
+                        >
+                          product title - item title
+                        </h4>
+                        <div
+                          className="c-line-items__details-sku"
+                        >
+                          <span />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="c-line-items__quantity"
+                    >
+                      <div
+                        className="c-line-items__quantity-header"
+                      >
+                        <span>
+                          Quantity
+                        </span>
+                      </div>
+                      <span
+                        className="c-line-items__quantity-amount"
+                      >
+                        1
+                      </span>
+                    </div>
+                    <div
+                      className="c-line-items__amounts"
+                    >
+                      <a
+                        className="c-line-items__amount c-line-items__amount--total"
+                      >
+                        £
+                        1440.00
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </LineItems>
+          </div>
+          <div
+            className="o-col-8-13"
+          >
+            <div
+              className="c-cart-summary"
+            >
+              <dl
+                aria-label="Subtotal"
+              >
+                <dt>
+                   Subtotal: 
+                </dt>
+                <dd>
+                   £
+                  1516.80
+                   
+                </dd>
+              </dl>
+              <dl
+                aria-label="Taxes"
+              >
+                <dt>
+                   UK VAT 20% (Included in Price): 
+                </dt>
+                <dd>
+                   £
+                  247.00
+                   
+                </dd>
+              </dl>
+              <dl
+                aria-label="Shipping"
+              >
+                <dt>
+                   Shipping Total: 
+                </dt>
+                <dd>
+                   £
+                  30.98
+                   
+                </dd>
+              </dl>
+              <dl
+                aria-label="Total"
+                className="c-cart-summary__total"
+              >
+                <dt>
+                   Total: 
+                </dt>
+                <dd>
+                   £
+                  1506.00
+                   
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c-order-single__item c-order-single__item--full"
+    >
+      <div
+        className="c-order-single__body"
+      >
+        <a
+          className="o-button o-button--primary"
+          href="/account/orders"
+        >
+          View all orders
+        </a>
+      </div>
+    </div>
+  </div>
+</OrderSingle>
+`;

--- a/packages/shift-react-components/__tests__/components/orders/order-single.spec.js
+++ b/packages/shift-react-components/__tests__/components/orders/order-single.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 import format from 'date-fns/format'
 
 // Component
-import { OrderList } from '../../../src/components/orders/order-list'
+import { OrderSingle } from '../../../src/components/orders/order-single'
 
 // Lib
 import { penceToPounds } from '../../../src/lib/pence-to-pounds'
@@ -14,17 +14,21 @@ import orders from '../../fixtures/orders'
 test('renders correctly', () => {
   // Act
   const wrapper = mount(
-    <OrderList orders={orders} />
+    <OrderSingle order={orders.data[0]} />
   )
 
   const instance = wrapper.instance()
 
   const order = orders.data[0]
+  const shippingTotal = penceToPounds(instance.calculateShippingTotal(order))
+  const orderSubTotal = penceToPounds(instance.calculateSubTotal(order))
   const orderTotal = penceToPounds(order.pricing.total_inc_tax)
   const orderDate = format(new Date(order.placed_at), 'MMM D, YYYY')
 
   // Assert
   expect(wrapper).toMatchSnapshot()
+  expect(wrapper).toIncludeText(shippingTotal)
+  expect(wrapper).toIncludeText(orderSubTotal)
   expect(wrapper).toIncludeText(orderTotal)
   expect(wrapper).toIncludeText(orderDate)
 })

--- a/packages/shift-react-components/src/components/account/orders.js
+++ b/packages/shift-react-components/src/components/account/orders.js
@@ -18,7 +18,12 @@ export class AccountOrders extends Component {
     this.props.fetchOrders()
   }
 
-  renderOrdersList (orders) {
+  /**
+   * Render the list of orders, or the individual order
+   * @param  {Object} orders
+   * @return {string} - HTML markup for the component
+   */
+  renderOrders (orders) {
     const { currentOrderRef, updateCurrentOrder } = this.props
 
     if (orders.data.length === 0) {
@@ -56,7 +61,7 @@ export class AccountOrders extends Component {
 
     return (
       <div className='c-order-history'>
-        { loading ? <Loading /> : this.renderOrdersList(orders) }
+        { loading ? <Loading /> : this.renderOrders(orders) }
       </div>
     )
   }

--- a/packages/shift-react-components/src/components/account/orders.js
+++ b/packages/shift-react-components/src/components/account/orders.js
@@ -36,22 +36,11 @@ export class AccountOrders extends Component {
   render () {
     const { orders, orders: { loading } } = this.props
 
-    if (loading) {
-      return (
-        <>
-          <div className='c-order-history'>
-            { this.renderAccountBanner() }
-            <Loading />
-          </div>
-        </>
-      )
-    } else {
-      return (
-        <div className='c-order-history'>
-          { this.renderAccountBanner() }
-          { this.renderOrdersList(orders) }
-        </div>
-      )
-    }
+    return (
+      <div className='c-order-history'>
+        { this.renderAccountBanner() }
+        { loading ? <Loading /> : this.renderOrdersList(orders) }
+      </div>
+    )
   }
 }

--- a/packages/shift-react-components/src/components/account/orders.js
+++ b/packages/shift-react-components/src/components/account/orders.js
@@ -1,10 +1,11 @@
 // Libraries
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 
 // Lib
 import Config from '../../lib/config'
 import { Loading } from '../../objects/loading'
 import { OrderList } from '../../components/orders/order-list'
+import { OrderSingle } from '../../components/orders/order-single'
 
 export class AccountOrders extends Component {
   constructor (props) {
@@ -22,7 +23,19 @@ export class AccountOrders extends Component {
       return (<p>No previous orders found.</p>)
     }
 
-    return (<OrderList orders={orders} />)
+    return (
+      <Fragment>
+        <OrderList orders={orders} />
+        { orders.data.map((order) => {
+          return (
+            <OrderSingle
+              key={order.id}
+              order={order}
+            />
+          )
+        })}
+      </Fragment>
+    )
   }
 
   renderAccountBanner () {

--- a/packages/shift-react-components/src/components/account/orders.js
+++ b/packages/shift-react-components/src/components/account/orders.js
@@ -19,30 +19,35 @@ export class AccountOrders extends Component {
   }
 
   renderOrdersList (orders) {
+    const { currentOrderRef, updateCurrentOrder } = this.props
+
     if (orders.data.length === 0) {
       return (<p>No previous orders found.</p>)
     }
 
+    if (currentOrderRef) {
+      const currentOrder = orders.data.find((order) => {
+        return order.reference === currentOrderRef
+      })
+
+      return (
+        <OrderSingle
+          order={currentOrder}
+          updateCurrentOrder={updateCurrentOrder}
+        />
+      )
+    }
+
     return (
       <Fragment>
-        <OrderList orders={orders} />
-        { orders.data.map((order) => {
-          return (
-            <OrderSingle
-              key={order.id}
-              order={order}
-            />
-          )
-        })}
+        <div className='c-order-history__nav'>
+          <h2>Order History</h2>
+        </div>
+        <OrderList
+          orders={orders}
+          updateCurrentOrder={updateCurrentOrder}
+        />
       </Fragment>
-    )
-  }
-
-  renderAccountBanner () {
-    return (
-      <div className='c-order-history__nav'>
-        <h2>Order History</h2>
-      </div>
     )
   }
 
@@ -51,7 +56,6 @@ export class AccountOrders extends Component {
 
     return (
       <div className='c-order-history'>
-        { this.renderAccountBanner() }
         { loading ? <Loading /> : this.renderOrdersList(orders) }
       </div>
     )

--- a/packages/shift-react-components/src/components/cart/line-items.js
+++ b/packages/shift-react-components/src/components/cart/line-items.js
@@ -1,5 +1,5 @@
 // Libraries
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 
 // Lib
@@ -73,17 +73,15 @@ export class LineItems extends Component {
    */
   renderButtonsAndTotal (lineItem) {
     return (
-      <>
-        <div className='c-line-items__amounts'>
-          { lineItem.sub_total !== lineItem.total && (
-            <>
-              <a className='c-line-items__amount'>&pound;{ decimalPrice(lineItem.sub_total) }</a>
-              <a className='c-line-items__amount c-line-items__amount--discount'>- &pound;{ decimalPrice(lineItem.total_discount) }</a>
-            </>
-          ) }
-          <a className='c-line-items__amount c-line-items__amount--total'>&pound;{ decimalPrice(lineItem.total) }</a>
-        </div>
-      </>
+      <div className='c-line-items__amounts'>
+        { lineItem.sub_total !== lineItem.total && (
+          <Fragment>
+            <a className='c-line-items__amount'>&pound;{ decimalPrice(lineItem.sub_total) }</a>
+            <a className='c-line-items__amount c-line-items__amount--discount'>- &pound;{ decimalPrice(lineItem.total_discount) }</a>
+          </Fragment>
+        ) }
+        <a className='c-line-items__amount c-line-items__amount--total'>&pound;{ decimalPrice(lineItem.total) }</a>
+      </div>
     )
   }
 
@@ -105,13 +103,13 @@ export class LineItems extends Component {
             </span>
           </div>
         </div>
-        <div className='c-line-items__remove'>
+        { this.props.deleteItem && <div className='c-line-items__remove'>
           <div className='c-line-items__delete'>
             <a className='c-line-items__delete-button' data-id={lineItem.id} onClick={this.props.deleteItem} >
               Delete
             </a>
           </div>
-        </div>
+        </div> }
       </div>
     )
   }
@@ -124,12 +122,10 @@ export class LineItems extends Component {
    */
   renderParams (lineItem) {
     return (
-      <>
-        <div className='c-line-items__quantity'>
-          <div className='c-line-items__quantity-header'><span>Quantity</span></div>
-          { this.renderLineItemQuantity(lineItem) }
-        </div>
-      </>
+      <div className='c-line-items__quantity'>
+        <div className='c-line-items__quantity-header'><span>Quantity</span></div>
+        { this.renderLineItemQuantity(lineItem) }
+      </div>
     )
   }
 

--- a/packages/shift-react-components/src/components/orders/order-list.js
+++ b/packages/shift-react-components/src/components/orders/order-list.js
@@ -6,10 +6,6 @@ import t from 'typy'
 // Lib
 import { penceToPounds } from '../../lib/pence-to-pounds'
 
-// Components
-
-import Link from '../../objects/link'
-
 export class OrderList extends PureComponent {
   /**
   * Render the order details

--- a/packages/shift-react-components/src/components/orders/order-list.js
+++ b/packages/shift-react-components/src/components/orders/order-list.js
@@ -19,6 +19,8 @@ export class OrderList extends PureComponent {
   * @return {string} - HTML markup for the component
   */
   renderOrderDetails (order) {
+    const { updateCurrentOrder } = this.props
+
     const orderDate = format(new Date(order.placed_at), 'MMM D, YYYY')
     const orderTotal = penceToPounds(t(order, 'pricing.total_inc_tax').safeObject)
 
@@ -32,7 +34,7 @@ export class OrderList extends PureComponent {
       label: 'Cost',
       value: orderTotal
     }, {
-      value: <Link href={`/account/orders/${order.id}`} className='o-button o-button--primary'>View Details</Link>
+      value: <a href={`/account/orders/${order.reference}`} className='o-button o-button--primary' onClick={(event) => updateCurrentOrder(event, order.reference)}>View Details</a>
     }].map((column, columnIndex) => {
       return (
         <div

--- a/packages/shift-react-components/src/components/orders/order-list.js
+++ b/packages/shift-react-components/src/components/orders/order-list.js
@@ -7,55 +7,10 @@ import t from 'typy'
 import { penceToPounds } from '../../lib/pence-to-pounds'
 
 // Components
-import { OrderLineItems } from './order-line-items'
-import ShippingAddresses from './shipping-addresses'
 
 import Link from '../../objects/link'
 
 export class OrderList extends PureComponent {
-  /**
-  * Render the total shipping costs in the order list
-  * @param  {Object} order
-  * @return {string} - HTML markup for the component
-  */
-  renderShippingTotal (order) {
-    const shippingTotal = order.shipping_methods.reduce(
-      (accumulator, currentValue) => accumulator + currentValue.price, 0
-    )
-
-    return penceToPounds(shippingTotal)
-  }
-
-  /**
-  * Render the total prices for the line item
-  * @param  {Object} order
-  * @param  {Object} orderDate
-  * @param  {Object} total
-  * @return {string} - HTML markup for the component
-  */
-  renderOrderSummary (order, orderDate, total) {
-    return (
-      <div className='c-order-history__order-summary'>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Date of Order: </p>
-          <a className='u-inline-block'>{ orderDate }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Items: </p>
-          <a className='u-inline-block'>{ order.line_items.length }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Order Number: </p>
-          <a className='u-inline-block'>{ order.reference }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Total: </p>
-          <a className='u-inline-block'>&pound;{ total }</a>
-        </div>
-      </div>
-    )
-  }
-
   /**
   * Render the order details
   * @param  {Object} order

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -84,7 +84,7 @@ export class OrderSingle extends PureComponent {
   }
 
   render () {
-    const { order } = this.props
+    const { order, updateCurrentOrder } = this.props
     const lineItems = this.formatLineItems(order.line_items)
 
     const items = [{
@@ -95,7 +95,7 @@ export class OrderSingle extends PureComponent {
       body: format(new Date(order.placed_at), 'MMM D, YYYY')
     }, {
       header: 'Cost',
-      body: `&pound;${penceToPounds(order.pricing.total_inc_tax)}`
+      body: `£${penceToPounds(order.pricing.total_inc_tax)}`
     }, {
       header: 'Shipping Method',
       body: order.shipping_methods[0].label
@@ -137,19 +137,19 @@ export class OrderSingle extends PureComponent {
                   <div className='c-cart-summary'>
                     <dl aria-label='Subtotal'>
                       <dt> Subtotal: </dt>
-                      <dd> &pound;{ penceToPounds(this.calculateSubTotal(order)) } </dd>
+                      <dd> £{ penceToPounds(this.calculateSubTotal(order)) } </dd>
                     </dl>
                     <dl aria-label='Taxes'>
                       <dt> UK VAT 20% (Included in Price): </dt>
-                      <dd> &pound;{ penceToPounds(this.calculateTax(order)) } </dd>
+                      <dd> £{ penceToPounds(this.calculateTax(order)) } </dd>
                     </dl>
                     <dl aria-label='Shipping'>
                       <dt> Shipping Total: </dt>
-                      <dd> &pound;{ penceToPounds(this.calculateShippingTotal(order)) } </dd>
+                      <dd> £{ penceToPounds(this.calculateShippingTotal(order)) } </dd>
                     </dl>
                     <dl aria-label='Total' className='c-cart-summary__total'>
                       <dt> Total: </dt>
-                      <dd> &pound;{ penceToPounds(order.pricing.total_inc_tax) } </dd>
+                      <dd> £{ penceToPounds(order.pricing.total_inc_tax) } </dd>
                     </dl>
                   </div>
                 </div>
@@ -158,7 +158,13 @@ export class OrderSingle extends PureComponent {
           </div>
           <div className='c-order-single__item c-order-single__item--full'>
             <div className='c-order-single__body'>
-              <Link href='/account/orders' className='o-button o-button--primary'>View all orders</Link>
+              <a
+                href='/account/orders'
+                className='o-button o-button--primary'
+                onClick={updateCurrentOrder}
+              >
+                View all orders
+              </a>
             </div>
           </div>
 

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -1,0 +1,100 @@
+// Libraries
+import React, { PureComponent } from 'react'
+import format from 'date-fns/format'
+import t from 'typy'
+
+// Lib
+import { penceToPounds } from '../../lib/pence-to-pounds'
+
+// Components
+import ShippingAddresses from './shipping-addresses'
+
+import Link from '../../objects/link'
+
+export class OrderSingle extends PureComponent {
+  /**
+  * Render the total shipping costs in the order list
+  * @param  {Object} order
+  * @return {string} - HTML markup for the component
+  */
+  renderShippingTotal (order) {
+    const shippingTotal = order.shipping_methods.reduce(
+      (accumulator, currentValue) => accumulator + currentValue.price, 0
+    )
+
+    return penceToPounds(shippingTotal)
+  }
+
+  /**
+  * Render the total prices for the line item
+  * @param  {Object} order
+  * @param  {Object} orderDate
+  * @param  {Object} total
+  * @return {string} - HTML markup for the component
+  */
+  renderOrderSummary (order, orderDate, total) {
+    return (
+      <div className='c-order-history__order-summary'>
+        <div className='c-order-history__order-summary_params'>
+          <p className='u-bold u-inline-block'>Date of Order: </p>
+          <a className='u-inline-block'>{ orderDate }</a>
+        </div>
+        <div className='c-order-history__order-summary_params'>
+          <p className='u-bold u-inline-block'>Items: </p>
+          <a className='u-inline-block'>{ order.line_items.length }</a>
+        </div>
+        <div className='c-order-history__order-summary_params'>
+          <p className='u-bold u-inline-block'>Order Number: </p>
+          <a className='u-inline-block'>{ order.reference }</a>
+        </div>
+        <div className='c-order-history__order-summary_params'>
+          <p className='u-bold u-inline-block'>Total: </p>
+          <a className='u-inline-block'>&pound;{ total }</a>
+        </div>
+      </div>
+    )
+  }
+
+  /**
+  * Render the order details
+  * @param  {Object} order
+  * @param  {Object} orderDate
+  * @param  {Object} total
+  * @return {string} - HTML markup for the component
+  */
+  renderOrderDetails (order) {
+    const orderDate = format(new Date(order.placed_at), 'MMM D, YYYY')
+    const orderTotal = penceToPounds(t(order, 'pricing.total_inc_tax').safeObject)
+
+    return [{
+      label: 'Order No.',
+      value: order.reference
+    }, {
+      label: 'Order Date',
+      value: orderDate
+    }, {
+      label: 'Cost',
+      value: orderTotal
+    }, {
+      value: <Link href={`/account/orders/${order.id}`} className='o-button o-button--primary'>View Details</Link>
+    }].map((column, columnIndex) => {
+      return (
+        <div
+          key={columnIndex}
+          className='c-order-history-table__col'
+        >
+          { column.label && <span className='c-order-history-table__label'>{ column.label }</span> }
+          { column.value }
+        </div>
+      )
+    })
+  }
+
+  render () {
+    const { order } = this.props
+
+    return (
+      <h1>{ order.id }</h1>
+    )
+  }
+}

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -1,5 +1,5 @@
 // Libraries
-import React, { PureComponent } from 'react'
+import React, { PureComponent, Fragment } from 'react'
 import format from 'date-fns/format'
 import t from 'typy'
 
@@ -8,6 +8,7 @@ import { penceToPounds } from '../../lib/pence-to-pounds'
 
 // Components
 import ShippingAddresses from './shipping-addresses'
+import { LineItems } from '../cart/line-items'
 
 import Link from '../../objects/link'
 
@@ -25,76 +26,87 @@ export class OrderSingle extends PureComponent {
     return penceToPounds(shippingTotal)
   }
 
-  /**
-  * Render the total prices for the line item
-  * @param  {Object} order
-  * @param  {Object} orderDate
-  * @param  {Object} total
-  * @return {string} - HTML markup for the component
-  */
-  renderOrderSummary (order, orderDate, total) {
-    return (
-      <div className='c-order-history__order-summary'>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Date of Order: </p>
-          <a className='u-inline-block'>{ orderDate }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Items: </p>
-          <a className='u-inline-block'>{ order.line_items.length }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Order Number: </p>
-          <a className='u-inline-block'>{ order.reference }</a>
-        </div>
-        <div className='c-order-history__order-summary_params'>
-          <p className='u-bold u-inline-block'>Total: </p>
-          <a className='u-inline-block'>&pound;{ total }</a>
-        </div>
-      </div>
-    )
-  }
-
-  /**
-  * Render the order details
-  * @param  {Object} order
-  * @param  {Object} orderDate
-  * @param  {Object} total
-  * @return {string} - HTML markup for the component
-  */
-  renderOrderDetails (order) {
-    const orderDate = format(new Date(order.placed_at), 'MMM D, YYYY')
-    const orderTotal = penceToPounds(t(order, 'pricing.total_inc_tax').safeObject)
-
-    return [{
-      label: 'Order No.',
-      value: order.reference
-    }, {
-      label: 'Order Date',
-      value: orderDate
-    }, {
-      label: 'Cost',
-      value: orderTotal
-    }, {
-      value: <Link href={`/account/orders/${order.id}`} className='o-button o-button--primary'>View Details</Link>
-    }].map((column, columnIndex) => {
-      return (
-        <div
-          key={columnIndex}
-          className='c-order-history-table__col'
-        >
-          { column.label && <span className='c-order-history-table__label'>{ column.label }</span> }
-          { column.value }
-        </div>
-      )
+  formatLineItems (lineItems) {
+    return lineItems.map((lineItem, lineItemIndex) => {
+      return {
+        id: lineItemIndex,
+        item: {
+          sku: lineItem.sku,
+          title: 'item title',
+          picture_url: lineItem.image_urls[0],
+          product: {
+            title: 'product title',
+            slug: 'slug'
+          }
+        },
+        unit_quantity: lineItem.quantity,
+        total: (lineItem.pricing.line_total_inc_tax / 100),
+        sub_total: (lineItem.pricing.line_total_inc_tax / 100)
+      }
     })
   }
 
   render () {
     const { order } = this.props
+    const lineItems = this.formatLineItems(order.line_items)
 
     return (
-      <h1>{ order.id }</h1>
+      <Fragment>
+        <div className='c-order-history__nav'>
+          <h2>Order { order.reference }</h2>
+        </div>
+        <div className='c-order-single'>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Order No.</h5>
+            <div className='c-order-single__body'>{ order.reference }</div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Order Date</h5>
+            <div className='c-order-single__body'>{ format(new Date(order.placed_at), 'MMM D, YYYY') }</div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Cost</h5>
+            <div className='c-order-single__body'>{ penceToPounds(t(order, 'pricing.total_inc_tax').safeObject) }</div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Shipping Method</h5>
+            <div className='c-order-single__body'>{ order.shipping_methods[0].label }</div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Billing Address</h5>
+            <div className='c-order-single__body'>
+              <ShippingAddresses addresses={order.shipping_addresses} />
+            </div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Shipping Address</h5>
+            <div className='c-order-single__body'>
+              <ShippingAddresses addresses={order.shipping_addresses} />
+            </div>
+          </div>
+          <div className='c-order-single__item'>
+            <h5 className='c-order-single__header'>Currency</h5>
+            <div className='c-order-single__body'>
+              { order.pricing.currency }
+            </div>
+          </div>
+          <div className='c-order-single__item c-order-single__item--full'>
+            <h5 className='c-order-single__header'>Order Summary</h5>
+            <div className='c-order-single__body'>
+              <LineItems
+                lineItems={lineItems}
+                lineItemsCount={lineItems.length}
+              />
+            </div>
+          </div>
+          <div className='c-order-single__item c-order-single__item--full'>
+            <div className='c-order-single__body'>
+              <Link href='/account/orders' className='o-button o-button--primary'>View all orders</Link>
+            </div>
+          </div>
+
+        </div>
+      </Fragment>
     )
   }
 }

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -9,8 +9,6 @@ import { penceToPounds } from '../../lib/pence-to-pounds'
 import ShippingAddresses from './shipping-addresses'
 import { LineItems } from '../cart/line-items'
 
-import Link from '../../objects/link'
-
 export class OrderSingle extends PureComponent {
   /**
    * Calculate the subtotal based on each line item price

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -52,7 +52,7 @@ export class OrderSingle extends PureComponent {
         id: lineItemIndex,
         item: {
           sku: lineItem.sku,
-          title: 'item title',
+          title: lineItem.sku,
           picture_url: lineItem.image_urls[0],
           product: {
             title: 'product title',

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -12,11 +12,17 @@ import { LineItems } from '../cart/line-items'
 import Link from '../../objects/link'
 
 export class OrderSingle extends PureComponent {
+  /**
+   * Calculate the subtotal based on each line item price
+   * @param  {Object} order
+   * @return {Number}
+   */
   calculateSubTotal (order) {
     return order.line_items.reduce(
       (accumulator, currentValue) => accumulator + currentValue.pricing.line_total_inc_tax, 0
     )
   }
+
   /**
    * Render the total shipping costs in the order list
    * @param  {Object} order
@@ -28,10 +34,20 @@ export class OrderSingle extends PureComponent {
     )
   }
 
+  /**
+   * Get the tax amount based on the totals
+   * @param  {Object} order
+   * @return {Number}
+   */
   calculateTax (order) {
     return order.pricing.total_inc_tax - order.pricing.total_ex_tax
   }
 
+  /**
+   * Reformat the line items to they'll work with the <LineItems /> component
+   * @param  {Array} lineItems
+   * @return {Array}
+   */
   formatLineItems (lineItems) {
     return lineItems.map((lineItem, lineItemIndex) => {
       return {
@@ -52,9 +68,47 @@ export class OrderSingle extends PureComponent {
     })
   }
 
+  /**
+   * Render each part of the order items
+   * @param  {String}                 options.header
+   * @param  {String|Number|Element0} options.body
+   * @return {String} - HTML markup for the component
+   */
+  renderItem ({ header, body }) {
+    return (
+      <Fragment>
+        { header && <h5 className='c-order-single__header'>{ header }</h5> }
+        { body && <div className='c-order-single__body'>{ body }</div> }
+      </Fragment>
+    )
+  }
+
   render () {
     const { order } = this.props
     const lineItems = this.formatLineItems(order.line_items)
+
+    const items = [{
+      header: 'Order No.',
+      body: order.reference
+    }, {
+      header: 'Order Date',
+      body: format(new Date(order.placed_at), 'MMM D, YYYY')
+    }, {
+      header: 'Cost',
+      body: `&pound;${penceToPounds(order.pricing.total_inc_tax)}`
+    }, {
+      header: 'Shipping Method',
+      body: order.shipping_methods[0].label
+    }, {
+      header: 'Billing Address',
+      body: <ShippingAddresses addresses={order.shipping_addresses} />
+    }, {
+      header: 'Shipping Address',
+      body: <ShippingAddresses addresses={order.shipping_addresses} />
+    }, {
+      header: 'Currency',
+      body: order.pricing.currency
+    }]
 
     return (
       <Fragment>
@@ -62,40 +116,13 @@ export class OrderSingle extends PureComponent {
           <h2>Order { order.reference }</h2>
         </div>
         <div className='c-order-single'>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Order No.</h5>
-            <div className='c-order-single__body'>{ order.reference }</div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Order Date</h5>
-            <div className='c-order-single__body'>{ format(new Date(order.placed_at), 'MMM D, YYYY') }</div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Cost</h5>
-            <div className='c-order-single__body'>&pound;{ penceToPounds(order.pricing.total_inc_tax) }</div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Shipping Method</h5>
-            <div className='c-order-single__body'>{ order.shipping_methods[0].label }</div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Billing Address</h5>
-            <div className='c-order-single__body'>
-              <ShippingAddresses addresses={order.shipping_addresses} />
-            </div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Shipping Address</h5>
-            <div className='c-order-single__body'>
-              <ShippingAddresses addresses={order.shipping_addresses} />
-            </div>
-          </div>
-          <div className='c-order-single__item'>
-            <h5 className='c-order-single__header'>Currency</h5>
-            <div className='c-order-single__body'>
-              { order.pricing.currency }
-            </div>
-          </div>
+          { items.map((item, itemIndex) => {
+            return (
+              <div key={itemIndex} className='c-order-single__item'>
+                { this.renderItem(item) }
+              </div>
+            )
+          }) }
           <div className='c-order-single__item c-order-single__item--full'>
             <h5 className='c-order-single__header'>Order Summary</h5>
             <div className='c-order-single__body'>

--- a/packages/shift-react-components/src/components/orders/order-single.js
+++ b/packages/shift-react-components/src/components/orders/order-single.js
@@ -1,7 +1,6 @@
 // Libraries
 import React, { PureComponent, Fragment } from 'react'
 import format from 'date-fns/format'
-import t from 'typy'
 
 // Lib
 import { penceToPounds } from '../../lib/pence-to-pounds'
@@ -13,17 +12,24 @@ import { LineItems } from '../cart/line-items'
 import Link from '../../objects/link'
 
 export class OrderSingle extends PureComponent {
+  calculateSubTotal (order) {
+    return order.line_items.reduce(
+      (accumulator, currentValue) => accumulator + currentValue.pricing.line_total_inc_tax, 0
+    )
+  }
   /**
-  * Render the total shipping costs in the order list
-  * @param  {Object} order
-  * @return {string} - HTML markup for the component
-  */
-  renderShippingTotal (order) {
-    const shippingTotal = order.shipping_methods.reduce(
+   * Render the total shipping costs in the order list
+   * @param  {Object} order
+   * @return {string} - HTML markup for the component
+   */
+  calculateShippingTotal (order) {
+    return order.shipping_methods.reduce(
       (accumulator, currentValue) => accumulator + currentValue.price, 0
     )
+  }
 
-    return penceToPounds(shippingTotal)
+  calculateTax (order) {
+    return order.pricing.total_inc_tax - order.pricing.total_ex_tax
   }
 
   formatLineItems (lineItems) {
@@ -66,7 +72,7 @@ export class OrderSingle extends PureComponent {
           </div>
           <div className='c-order-single__item'>
             <h5 className='c-order-single__header'>Cost</h5>
-            <div className='c-order-single__body'>{ penceToPounds(t(order, 'pricing.total_inc_tax').safeObject) }</div>
+            <div className='c-order-single__body'>&pound;{ penceToPounds(order.pricing.total_inc_tax) }</div>
           </div>
           <div className='c-order-single__item'>
             <h5 className='c-order-single__header'>Shipping Method</h5>
@@ -93,10 +99,34 @@ export class OrderSingle extends PureComponent {
           <div className='c-order-single__item c-order-single__item--full'>
             <h5 className='c-order-single__header'>Order Summary</h5>
             <div className='c-order-single__body'>
-              <LineItems
-                lineItems={lineItems}
-                lineItemsCount={lineItems.length}
-              />
+              <div className='o-grid-container'>
+                <div className='o-col-1-7'>
+                  <LineItems
+                    lineItems={lineItems}
+                    lineItemsCount={lineItems.length}
+                  />
+                </div>
+                <div className='o-col-8-13'>
+                  <div className='c-cart-summary'>
+                    <dl aria-label='Subtotal'>
+                      <dt> Subtotal: </dt>
+                      <dd> &pound;{ penceToPounds(this.calculateSubTotal(order)) } </dd>
+                    </dl>
+                    <dl aria-label='Taxes'>
+                      <dt> UK VAT 20% (Included in Price): </dt>
+                      <dd> &pound;{ penceToPounds(this.calculateTax(order)) } </dd>
+                    </dl>
+                    <dl aria-label='Shipping'>
+                      <dt> Shipping Total: </dt>
+                      <dd> &pound;{ penceToPounds(this.calculateShippingTotal(order)) } </dd>
+                    </dl>
+                    <dl aria-label='Total' className='c-cart-summary__total'>
+                      <dt> Total: </dt>
+                      <dd> &pound;{ penceToPounds(order.pricing.total_inc_tax) } </dd>
+                    </dl>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div className='c-order-single__item c-order-single__item--full'>

--- a/packages/shift-react-components/src/lib/pence-to-pounds.js
+++ b/packages/shift-react-components/src/lib/pence-to-pounds.js
@@ -6,5 +6,5 @@
  */
 
 export function penceToPounds (priceInPence) {
-  return (priceInPence / 100).toFixed(2)
+  return (Number(priceInPence) / 100).toFixed(2)
 }

--- a/packages/shift-react-components/src/scss/60_components/__all.scss
+++ b/packages/shift-react-components/src/scss/60_components/__all.scss
@@ -25,6 +25,7 @@
 @import 'c-myaccount';
 @import 'c-nav';
 @import 'c-order-history';
+@import 'c-order-single';
 @import 'c-order-summary';
 @import 'c-order';
 @import 'c-payment-icons';

--- a/packages/shift-react-components/src/scss/60_components/_c-order-history.scss
+++ b/packages/shift-react-components/src/scss/60_components/_c-order-history.scss
@@ -206,3 +206,69 @@
     margin: $global-spacing-unit-tiny 0;
   }
 }
+
+
+.c-order-history-table {
+  width: 100%;
+  background-color: $background-light-grey;
+
+  @media (min-width: 550px) {
+    display: table;
+  }
+}
+
+  .c-order-history-table__row {
+    border-bottom: 1px solid $background-light;
+
+    @media (min-width: 550px) {
+      display: table-row;
+      border-bottom: 0;
+    }
+
+    &:last-child {
+      border-bottom: 0;
+
+      .c-order-history-table__col {
+        border-bottom: 0;
+      }      
+    }
+
+    &--header {
+      display: none;
+
+      @media (min-width: 550px) {
+        display: table-row;
+      }
+    }
+  }
+
+    .c-order-history-table__col {
+      padding: $global-spacing-unit-small;
+
+      @media (min-width: 550px) {
+        display: table-cell;
+        width: 25%;
+        border-bottom: 1px solid $background-light;
+
+        &:last-child {
+          text-align: right;
+        }
+      }
+
+      &--header {
+        font-weight: 700;
+      }
+
+      .o-button {
+        margin: 0;
+      }
+    }
+
+      .c-order-history-table__label {
+        display: block;
+        font-weight: 700;
+
+        @media (min-width: 550px) {
+          display: none;
+        }
+      }

--- a/packages/shift-react-components/src/scss/60_components/_c-order-single.scss
+++ b/packages/shift-react-components/src/scss/60_components/_c-order-single.scss
@@ -7,10 +7,14 @@
 
   .c-order-single__item {
     display: inline-block;
-    width: 25%;
+    width: 50%;
     vertical-align: top;
     font-size: 16px;
     margin-bottom: $global-spacing-unit;
+
+    @include breakpoint(tablet) {
+      width: 25%;
+    }
 
     &--full {
       width: 100%;
@@ -34,5 +38,38 @@
 
       .o-button {
         margin: 0;
+      }
+
+      .o-grid-container {
+        @include breakpoint(mobile) {
+          display: block;
+        }
+      }
+
+      .c-cart-summary {
+        padding: 0;
+        background-color: transparent;
+        margin-top: $global-spacing-unit-small;
+
+        @include breakpoint(tablet) {
+          margin-top: 0;
+        }
+
+        dl {
+          display: flex;
+          justify-content: space-between;
+
+          &:first-child {
+            margin-top: 0;
+          }
+        }
+
+        dt {
+          margin-left: 0;
+        }
+      }
+
+      .c-cart-summary__total {
+        font-weight: 700;
       }
     }

--- a/packages/shift-react-components/src/scss/60_components/_c-order-single.scss
+++ b/packages/shift-react-components/src/scss/60_components/_c-order-single.scss
@@ -1,0 +1,38 @@
+.c-order-single {
+  background-color: $background-light-grey;
+  margin: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+  .c-order-single__item {
+    display: inline-block;
+    width: 25%;
+    vertical-align: top;
+    font-size: 16px;
+    margin-bottom: $global-spacing-unit;
+
+    &--full {
+      width: 100%;
+      margin-bottom: 0;
+    }
+  }
+
+    .c-order-single__header {
+      margin: 0;
+      padding: $global-spacing-unit-small;
+    }
+
+    .c-order-single__body {
+      border-top: 1px solid $background-light;
+      padding: $global-spacing-unit-small;
+
+      .c-order-history__shipping-address {
+        margin: 0;
+        padding: 0;
+      }
+
+      .o-button {
+        margin: 0;
+      }
+    }


### PR DESCRIPTION
## Description

This PR changes the layout and styles of the order history page in the account section, to look more like the Trendy designs

## Related Issue

https://github.com/shiftcommerce/trendy-golf/issues/139

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [ ] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

1. Login to the customer area
2. Go to Orders
3. You should see a list of orders
4. You should be able to click into each order

### Dependencies Review

N/A
