### PR TITLE
Bugfix/Updated postcode validation

### DIFF
--- a/packages/shift-next/src/lib/input-field-validator.js
+++ b/packages/shift-next/src/lib/input-field-validator.js
@@ -61,7 +61,8 @@ class InputFieldValidator {
   }
 
   postcode () {
-    const regex = /^[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}$/i
+    // https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom
+    const regex = /^[A-Z]{1,2}[0-9]{1,2}[A-Z]{0,1} ?[0-9][A-Z]{2}$/i
     const validPostcode = (regex.test(this.value))
     return (validPostcode ? '' : `${this.value} - is not a valid ${this.formattedFieldName()}.`)
   }

--- a/packages/shift-next/test/lib/input-field-validator.test.js
+++ b/packages/shift-next/test/lib/input-field-validator.test.js
@@ -173,9 +173,66 @@ describe('InputFieldValidator', () => {
   })
 
   describe('Postcode validation', () => {
-    test('with valid postcode', () => {
+    let data = { name: 'postcode', rules: { postcode: true } }
+
+    test('with valid postcode - format: AA9A 9AA', () => {
       // Arrange
-      const data = { name: 'postcode', value: 'ls98ds', rules: { postcode: true } }
+      data.value = 'EC1A 1BB'
+
+      // Act
+      const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
+
+      // Assert
+      expect(validationMessage).toBe('')
+    })
+
+    test('with valid postcode - format: A9A 9AA', () => {
+      // Arrange
+      data.value = 'W1A 0AX'
+
+      // Act
+      const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
+
+      // Assert
+      expect(validationMessage).toBe('')
+    })
+
+    test('with valid postcode - format: A9 9AA', () => {
+      // Arrange
+      data.value = 'M1 1AE'
+
+      // Act
+      const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
+
+      // Assert
+      expect(validationMessage).toBe('')
+    })
+
+    test('with valid postcode - format: A99 9AA', () => {
+      // Arrange
+      data.value = 'B33 8TH'
+
+      // Act
+      const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
+
+      // Assert
+      expect(validationMessage).toBe('')
+    })
+
+    test('with valid postcode - format: AA9 9AA', () => {
+      // Arrange
+      data.value = 'CR2 6XH'
+
+      // Act
+      const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
+
+      // Assert
+      expect(validationMessage).toBe('')
+    })
+
+    test('with valid postcode - format: AA99 9AA', () => {
+      // Arrange
+      data.value = 'DN55 1PT'
 
       // Act
       const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()
@@ -186,7 +243,7 @@ describe('InputFieldValidator', () => {
 
     test('with invalid postcode', () => {
       // Arrange
-      const data = { name: 'postcode', value: 'ls9', rules: { postcode: true } }
+      data = { name: 'postcode', value: 'ls9', rules: { postcode: true } }
 
       // Act
       const validationMessage = new InputFieldValidator(data.name, data.value, data.rules).validate()

--- a/packages/shift-react-components/src/components/checkout/address-form.js
+++ b/packages/shift-react-components/src/components/checkout/address-form.js
@@ -1,5 +1,5 @@
 // Libraries
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import t from 'typy'
 
 // Lib
@@ -45,61 +45,55 @@ export class AddressForm extends Component {
     const rules = { required: true }
 
     return (
-      <>
-        <DropdownSelect
-          options={countries}
-          label='Country'
-          name={name}
-          value={formInput.country_code}
-          formName={formName}
-          required={rules.required}
-          rules={rules}
-          validationMessage={formInput.errors[name]}
-          onChange={onChange}
-          onBlur={onBlur}
-          prompt='Select a Country'
-        />
-      </>
+      <DropdownSelect
+        options={countries}
+        label='Country'
+        name={name}
+        value={formInput.country_code}
+        formName={formName}
+        required={rules.required}
+        rules={rules}
+        validationMessage={formInput.errors[name]}
+        onChange={onChange}
+        onBlur={onBlur}
+        prompt='Select a Country'
+      />
     )
   }
 
   renderInputField (formInput, fieldOption) {
     return (
-      <>
-        <Input
-          label={fieldOption.label}
-          className={fieldOption.className}
-          placeholder={fieldOption.placeholder}
-          name={fieldOption.name}
-          type={fieldOption.type}
-          value={fieldOption.value}
-          required={t(fieldOption, 'rules.required').safeObject}
-          validationMessage={formInput.errors[fieldOption.name]}
-          rules={fieldOption.rules}
-          formName={this.props.formName}
-          onChange={this.props.onChange}
-          onBlur={this.props.onBlur}
-        />
-      </>
+      <Input
+        label={fieldOption.label}
+        className={fieldOption.className}
+        placeholder={fieldOption.placeholder}
+        name={fieldOption.name}
+        type={fieldOption.type}
+        value={fieldOption.value}
+        required={t(fieldOption, 'rules.required').safeObject}
+        validationMessage={formInput.errors[fieldOption.name]}
+        rules={fieldOption.rules}
+        formName={this.props.formName}
+        onChange={this.props.onChange}
+        onBlur={this.props.onBlur}
+      />
     )
   }
 
   renderCheckbox (formInput, fieldOption) {
     return (
-      <>
-        <Checkbox
-          label={fieldOption.label}
-          className={fieldOption.className}
-          name={fieldOption.name}
-          checked={!!fieldOption.value}
-          required={t(fieldOption, 'rules.required').safeObject}
-          validationMessage={formInput.errors[fieldOption.name]}
-          rules={fieldOption.rules}
-          formName={this.props.formName}
-          onChange={this.props.onChange}
-          onBlur={this.props.onBlur}
-        />
-      </>
+      <Checkbox
+        label={fieldOption.label}
+        className={fieldOption.className}
+        name={fieldOption.name}
+        checked={!!fieldOption.value}
+        required={t(fieldOption, 'rules.required').safeObject}
+        validationMessage={formInput.errors[fieldOption.name]}
+        rules={fieldOption.rules}
+        formName={this.props.formName}
+        onChange={this.props.onChange}
+        onBlur={this.props.onBlur}
+      />
     )
   }
 
@@ -131,14 +125,14 @@ export class AddressForm extends Component {
     const fieldOption = { className: 'o-form__input-block', label: 'Company Name', name: 'companyName', value: formInput.companyName }
 
     return (
-      <>
+      <Fragment>
         { !(formInput.companyNameShown) &&
           <a href='#' onClick={() => onShowField(formName, 'companyNameShown')}>
             <p>+ Add Company Name (optional)</p>
           </a>
         }
         { formInput.companyNameShown && this.renderInputField(formInput, fieldOption) }
-      </>
+      </Fragment>
     )
   }
 
@@ -147,11 +141,7 @@ export class AddressForm extends Component {
     const formInput = checkout[formName]
     const fieldOption = { className: 'o-form__input-block', placeholder: 'Enter Address', label: 'Address 1', name: 'line_1', value: formInput.line_1, rules: { required: true } }
 
-    return (
-      <>
-        { this.renderInputField(formInput, fieldOption) }
-      </>
-    )
+    return this.renderInputField(formInput, fieldOption)
   }
 
   renderAddressLine2 () {
@@ -160,14 +150,14 @@ export class AddressForm extends Component {
     const fieldOption = { className: 'o-form__input-block', label: 'Address 2', name: 'line_2', value: formInput.line_2 }
 
     return (
-      <>
+      <Fragment>
         { !(formInput.address2Shown) &&
           <a href='#' onClick={() => onShowField(formName, 'address2Shown')}>
             <p>+ Add Address 2 (optional)</p>
           </a>
         }
         { formInput.address2Shown && this.renderInputField(formInput, fieldOption) }
-      </>
+      </Fragment>
     )
   }
 
@@ -180,17 +170,13 @@ export class AddressForm extends Component {
       { className: 'o-form__input-block', placeholder: 'Enter County', label: 'County', name: 'state', value: formInput.state }
     ]
 
-    return (
-      <>
-        { fieldOptions.map((fieldOption, index) => {
-          return (
-            <div key={index}>
-              { this.renderInputField(formInput, fieldOption) }
-            </div>
-          )
-        }) }
-      </>
-    )
+    return fieldOptions.map((fieldOption, index) => {
+      return (
+        <div key={index}>
+          { this.renderInputField(formInput, fieldOption) }
+        </div>
+      )
+    })
   }
 
   renderPhone () {
@@ -199,10 +185,10 @@ export class AddressForm extends Component {
     const fieldOption = { className: 'o-form__input-block', placeholder: 'Enter Phone', label: 'Phone', name: 'primary_phone', value: formInput.primary_phone, rules: { required: true, phone: true } }
 
     return (
-      <>
+      <Fragment>
         <p className='o-form__additional-label'>Required for any delivery related questions</p>
         { this.renderInputField(formInput, fieldOption) }
-      </>
+      </Fragment>
     )
   }
 
@@ -212,10 +198,10 @@ export class AddressForm extends Component {
     const fieldOption = { className: 'o-form__input-block', placeholder: 'Enter Email', label: 'Email', name: 'email', type: 'email', value: formInput.email, rules: { required: true, email: true } }
 
     return (
-      <>
+      <Fragment>
         <p className='o-form__additional-label'>Required for Order Confirmation Email</p>
         { this.renderInputField(formInput, fieldOption) }
-      </>
+      </Fragment>
     )
   }
 
@@ -227,12 +213,12 @@ export class AddressForm extends Component {
     const preferredShippingCheckboxOptions = { className: 'o-form__checkbox-label', label: 'Set as preferred shipping address', name: 'preferred_shipping', value: formInput.setAsPreferredShipping }
     const preferredBillingCheckboxOptions = { className: 'o-form__checkbox-label', label: 'Set as preferred billing address', name: 'preferred_billing', value: formInput.setAsPreferredBilling }
     return (
-      <>
+      <Fragment>
         { loggedIn && !formInput.formPreFilled && this.renderCheckbox(formInput, checkboxOptions) }
         { formInput.saveToAddressBook && this.renderCheckbox(formInput, preferredShippingCheckboxOptions) }
         { formInput.saveToAddressBook && this.renderCheckbox(formInput, preferredBillingCheckboxOptions) }
         { formInput.saveToAddressBook && this.renderInputField(formInput, inputOptions) }
-      </>
+      </Fragment>
     )
   }
 
@@ -245,10 +231,11 @@ export class AddressForm extends Component {
       value: formInput.newsletterOptIn,
       className: 'o-form__checkbox-label'
     }
+
     return (
-      <>
+      <Fragment>
         { formName === 'shippingAddress' && this.renderCheckbox(formInput, fieldOption) }
-      </>
+      </Fragment>
     )
   }
 }

--- a/packages/shift-react-components/src/objects/input.js
+++ b/packages/shift-react-components/src/objects/input.js
@@ -1,5 +1,5 @@
 // Libraries
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import classNames from 'classnames'
 
 // HOC
@@ -91,14 +91,12 @@ class Input extends Component {
     let inputFields = ''
 
     if (type === 'checkbox') {
-      inputFields = <>
+      inputFields = <Fragment>
         { this.renderInputField() }
         { this.renderLabel() }
-      </>
+      </Fragment>
     } else {
-      inputFields = <>
-        { this.renderLabel() }
-      </>
+      inputFields = this.renderLabel()
     }
 
     return (


### PR DESCRIPTION
## Description

This PR updates the postcode validation to accept all UK postcodes, as listed here: https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom

![image](https://user-images.githubusercontent.com/6663840/59929326-801d6400-9438-11e9-816e-0d125d95f9a7.png)

Also removes a few unneeded fragments from shift-react-components


## Related Issue

https://github.com/shiftcommerce/trendy-golf/issues/267

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [x] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [ ] Serverside rendering
- [x] Clientside rendering

1. Go through the checkout
2. On an address section, create a new address
3. Use an address such as `EC1A 1BB`, it should now be valid
4. All formats should now be valid

### Dependencies Review

N/A
