### PR TITLE
Bugfix/Changed menu items to use links

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.18",
+  "version": "0.22.19",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.18",
-    "@shiftcommerce/shift-next-routes": "^0.22.18",
-    "@shiftcommerce/shift-react-components": "^0.22.18",
+    "@shiftcommerce/shift-next": "^0.22.19",
+    "@shiftcommerce/shift-next-routes": "^0.22.19",
+    "@shiftcommerce/shift-react-components": "^0.22.19",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.18",
+    "@shiftcommerce/shift-node-api": "^0.22.19",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.18",
-    "@shiftcommerce/shift-react-components": "^0.22.18",
+    "@shiftcommerce/shift-node-api": "^0.22.19",
+    "@shiftcommerce/shift-react-components": "^0.22.19",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-next/src/layouts/my-account.js
+++ b/packages/shift-next/src/layouts/my-account.js
@@ -37,10 +37,6 @@ export class MyAccountLayout extends Component {
     )
   }
 
-  handleItemClick (location) {
-    Router.push(location)
-  }
-
   render () {
     const { menu, children } = this.props
 
@@ -51,7 +47,6 @@ export class MyAccountLayout extends Component {
         <div className='c-myaccount-main'>
           <Sidebar
             items={menu}
-            handleItemClick={this.handleItemClick}
             currentItem={this.state.currentItem}
           />
           <div className='c-myaccount-main__content'>

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",

--- a/packages/shift-react-components/src/components/account/sidebar-item.js
+++ b/packages/shift-react-components/src/components/account/sidebar-item.js
@@ -1,11 +1,24 @@
 // Libraries
-import React from 'react'
+import React, { PureComponent } from 'react'
 import classNames from 'classnames'
+import Config from '../../lib/config'
+import Link from '../../objects/link'
 
-export const SidebarItem = ({ label, location, current, handleItemClick }) => {
-  return (
-    <li onClick={() => handleItemClick(location)} className={classNames('c-sidebar__item', { 'c-sidebar__item--current': current })}>
-      { label }
-    </li>
-  )
+export class SidebarItem extends PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.Link = Config.get().Link || Link
+  }
+
+  render () {
+    const { label, location, current } = this.props
+    return (
+      <li className={classNames('c-sidebar__item', { 'c-sidebar__item--current': current })}>
+        <this.Link href={location} className='c-sidebar__link'>
+          { label }
+        </this.Link>
+      </li>
+    )
+  }
 }

--- a/packages/shift-react-components/src/components/account/sidebar.js
+++ b/packages/shift-react-components/src/components/account/sidebar.js
@@ -4,7 +4,7 @@ import { SidebarItem } from './sidebar-item'
 
 export class Sidebar extends Component {
   render () {
-    const { items, currentItem, handleItemClick } = this.props
+    const { items, currentItem } = this.props
 
     return (
       <ul className='c-sidebar'>
@@ -13,7 +13,6 @@ export class Sidebar extends Component {
             key={index}
             label={item.label}
             location={item.location}
-            handleItemClick={handleItemClick}
             current={item.label.toLowerCase() === (currentItem && currentItem.toLowerCase())}
           />
         )) }

--- a/packages/shift-react-components/src/scss/60_components/_c-sidebar.scss
+++ b/packages/shift-react-components/src/scss/60_components/_c-sidebar.scss
@@ -13,27 +13,29 @@
   }
 }
 
-.c-sidebar__item {
-  text-transform: uppercase;
-  padding: $global-spacing-unit-small 0;
-  padding-left: $global-spacing-unit-tiny;
-  border-bottom: 1px solid $border-divider;
-  background-image: url('data:image/svg+xml;charset=UTF8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-right"><polyline points="9 18 15 12 9 6"></polyline></svg>');
-  background-repeat: no-repeat;
-  background-position: right;
-  background-color: lighten($alert-orange, 100%);
-  cursor: pointer;
-  transition: all .2s;
+  .c-sidebar__item {
+    border-bottom: 1px solid $border-divider;
+    background-image: url('data:image/svg+xml;charset=UTF8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-right"><polyline points="9 18 15 12 9 6"></polyline></svg>');
+    background-repeat: no-repeat;
+    background-position: right;
+    background-color: lighten($alert-orange, 100%);
+    transition: all .2s;
 
-  &:hover {
-    background-color: lighten($alert-orange, 15%);
+    &:hover {
+      background-color: lighten($alert-orange, 15%);
+    }
+
+    &:first-of-type {
+      border-top: 1px solid $border-divider;
+    }
+
+    &--current {
+      font-weight: bold;
+    }
   }
 
-  &:first-of-type {
-    border-top: 1px solid $border-divider;
-  }
-
-  &--current {
-    font-weight: bold;
-  }
-}
+    .c-sidebar__link {
+      display: block;
+      text-transform: uppercase;
+      padding: $global-spacing-unit-small $global-spacing-unit $global-spacing-unit-small $global-spacing-unit-tiny;
+    }


### PR DESCRIPTION
## Description

This PR updates `shift-react-components/src/components/account/sidebar-item.js` to use `<Link>` for each menu item, instead of having a clickable `<li>`

The layout is now `<li><a href='...'>Label</a><li>`

## Related Issue

https://github.com/shiftcommerce/reference-site/pull/48

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [x] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

1. Login to the account section
2. The links in the sidebar menu should be anchor tags

### Dependencies Review

N/A
