### PR TITLE
Hotfix: Menu cache key

### DIFF
--- a/packages/shift-next-routes/src/lib/menu-cache.js
+++ b/packages/shift-next-routes/src/lib/menu-cache.js
@@ -2,6 +2,9 @@
 const { MemcachedStore } = require('./memcached-store')
 const { shiftApiConfig } = require('@shiftcommerce/shift-node-api')
 
+// Constants
+const defaultCacheKey = `menus/${shiftApiConfig.get().apiTenant}/data`
+
 /**
  *  MenuCache service
  *
@@ -15,7 +18,7 @@ class MenuCache {
    * @param {function} cache - cache client, eg. memcached
    * @param {string} cacheKey - the cache key to be used
    */
-  constructor (cache = MemcachedStore, cacheKey = 'menus/data', logger = shiftApiConfig.get().logger) {
+  constructor (cache = MemcachedStore, cacheKey = defaultCacheKey, logger = shiftApiConfig.get().logger) {
     this.cache = cache
     this.cacheKey = cacheKey
     this.defaultCacheDuration = parseInt(process.env.MENUS_CACHE_DURATION) || 300

--- a/packages/shift-next-routes/src/lib/menu-cache.js
+++ b/packages/shift-next-routes/src/lib/menu-cache.js
@@ -3,6 +3,7 @@ const { MemcachedStore } = require('./memcached-store')
 const { shiftApiConfig } = require('@shiftcommerce/shift-node-api')
 
 // Constants
+// Namespace menu cache key based on tenant
 const defaultCacheKey = `menus/${shiftApiConfig.get().apiTenant}/data`
 
 /**

--- a/packages/shift-next-routes/src/lib/menu-cache.js
+++ b/packages/shift-next-routes/src/lib/menu-cache.js
@@ -4,7 +4,7 @@ const { shiftApiConfig } = require('@shiftcommerce/shift-node-api')
 
 // Constants
 // Namespace menu cache key based on tenant
-const defaultCacheKey = `menus/${shiftApiConfig.get().apiTenant}/data`
+const defaultCacheKey = `${shiftApiConfig.get().apiTenant}/menus`
 
 /**
  *  MenuCache service
@@ -50,7 +50,7 @@ class MenuCache {
   async set (response, cacheDuration = this.defaultCacheDuration) {
     try {
       const result = await this.cache.set(this.cacheKey, JSON.stringify(response), { expires: cacheDuration })
-      this.log.info('Writing API menu response in cache: ', result)
+      this.log.info(`Writing API menu response in ${this.cacheKey} cache: `, result)
       return result
     } catch (error) {
       this.log.error('Error setting menu cache', error)

--- a/packages/shift-next-routes/test/lib/menu-cache.test.js
+++ b/packages/shift-next-routes/test/lib/menu-cache.test.js
@@ -11,6 +11,8 @@ const exampleCacheClient = {
   })
 }
 
+const { shiftApiConfig } = require('@shiftcommerce/shift-node-api')
+
 describe('initialisation', () => {
   test('instantialises the service with the given client', async () => {
     // Act
@@ -29,6 +31,17 @@ describe('initialisation', () => {
 
     // Assert
     expect(menuCache.cacheKey).toEqual(exampleCacheKey)
+  })
+
+  test('instantialises the service with a namespaced cache key', async () => {
+    // Arrange
+    const expectedCacheKey = `menus/${shiftApiConfig.get().apiTenant}/data`
+
+    // Act
+    const menuCache = new MenuCache(exampleCacheClient)
+
+    // Assert
+    expect(menuCache.cacheKey).toEqual(expectedCacheKey)
   })
 })
 

--- a/packages/shift-next-routes/test/lib/menu-cache.test.js
+++ b/packages/shift-next-routes/test/lib/menu-cache.test.js
@@ -35,7 +35,7 @@ describe('initialisation', () => {
 
   test('instantialises the service with a namespaced cache key', async () => {
     // Arrange
-    const expectedCacheKey = `menus/${shiftApiConfig.get().apiTenant}/data`
+    const expectedCacheKey = `${shiftApiConfig.get().apiTenant}/menus`
 
     // Act
     const menuCache = new MenuCache(exampleCacheClient)


### PR DESCRIPTION
## Description

PR namespaces the menu cache key based on the `API_TENANT` eg. 

Trendy:  `trendygolf/menus`
Reference:  `reference/menus`

## Related Issue

N/A

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [ ] All SHIFT library versions bumped and published (utilised in this PR) - N/A
- [x] Unit tests added/amended.
- [ ] Integration tests added/amended - N/A
- [ ] Environment variables supplied (.env.example also updated) - N/A

### How has/can this been tested?

![menu cache key](https://user-images.githubusercontent.com/4486874/60260342-3ff33100-98d1-11e9-875e-e5760b4b240a.png)

### Dependencies Review

N/A
