### PR TITLE
Bugfix: Checkout Step Labels

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.22.24",
+  "version": "0.22.25",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "main": "server/server.js",
   "repository": "https://github.com/shiftcommerce/shift-front-end-react.git",
   "author": "Shift Commerce",
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^8.1.1-canary.44",
-    "@shiftcommerce/shift-next": "^0.22.24",
-    "@shiftcommerce/shift-next-routes": "^0.22.24",
-    "@shiftcommerce/shift-react-components": "^0.22.24",
+    "@shiftcommerce/shift-next": "^0.22.25",
+    "@shiftcommerce/shift-next-routes": "^0.22.25",
+    "@shiftcommerce/shift-react-components": "^0.22.25",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "^0.19.0",

--- a/packages/shift-next-routes/package.json
+++ b/packages/shift-next-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next-routes",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "description": "",
   "main": "src/index.js",
   "repository": "https://github.com/shiftcommerce/shift-next-routes.git",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@paypal/checkout-server-sdk": "^1.0.0",
-    "@shiftcommerce/shift-node-api": "^0.22.24",
+    "@shiftcommerce/shift-node-api": "^0.22.25",
     "csurf": "^1.10.0",
     "express-ipfilter": "^1.0.1",
     "helmet": "^3.18.0",

--- a/packages/shift-next/package.json
+++ b/packages/shift-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "description": "",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
   "engines": {
@@ -44,8 +44,8 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@shiftcommerce/shift-node-api": "^0.22.24",
-    "@shiftcommerce/shift-react-components": "^0.22.24",
+    "@shiftcommerce/shift-node-api": "^0.22.25",
+    "@shiftcommerce/shift-react-components": "^0.22.25",
     "axios": "^0.19.0",
     "deep-equal": "^1.0.0",
     "js-cookie": "^2.2.0",

--- a/packages/shift-node-api/package.json
+++ b/packages/shift-node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-node-api",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "main": "src/index.js",
   "author": "Shift Commerce",
   "license": "ISC",

--- a/packages/shift-react-components/__tests__/components/checkout/__snapshots__/checkout-steps.spec.js.snap
+++ b/packages/shift-react-components/__tests__/components/checkout/__snapshots__/checkout-steps.spec.js.snap
@@ -97,7 +97,7 @@ exports[`Renders current step 1 correctly 1`] = `
             <div
               className="c-step-indicator__subtitle"
             >
-              Payment
+              Payment Details
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@ exports[`Renders current step 2 correctly 1`] = `
             <div
               className="c-step-indicator__subtitle"
             >
-              Payment
+              Payment Details
             </div>
           </div>
         </div>
@@ -367,7 +367,7 @@ exports[`Renders current step 3 correctly 1`] = `
             <div
               className="c-step-indicator__subtitle"
             >
-              Payment
+              Payment Details
             </div>
           </div>
         </div>
@@ -508,7 +508,7 @@ exports[`Renders current step 4 correctly 1`] = `
             <div
               className="c-step-indicator__subtitle c-step-indicator__subtitle--active"
             >
-              Payment
+              Payment Details
             </div>
           </div>
         </div>
@@ -654,7 +654,7 @@ exports[`Renders current step 5 correctly 1`] = `
               <div
                 className="c-step-indicator__subtitle c-step-indicator__subtitle--completed"
               >
-                Payment
+                Payment Details
               </div>
             </div>
           </Link>
@@ -784,7 +784,7 @@ exports[`Renders steps correctly 1`] = `
             <div
               className="c-step-indicator__subtitle"
             >
-              Payment
+              Payment Details
             </div>
           </div>
         </div>

--- a/packages/shift-react-components/__tests__/components/checkout/checkout-steps.spec.js
+++ b/packages/shift-react-components/__tests__/components/checkout/checkout-steps.spec.js
@@ -52,7 +52,7 @@ test('Renders current step 4 correctly', () => {
   // Assert
   expect(wrapper).toMatchSnapshot()
   expect(wrapper.find('Link').length).toEqual(3)
-  expect(wrapper.find('.c-step-indicator--active')).toIncludeText('Payment')
+  expect(wrapper.find('.c-step-indicator--active')).toIncludeText('Payment Details')
 })
 
 test('Renders current step 5 correctly', () => {

--- a/packages/shift-react-components/package.json
+++ b/packages/shift-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ANALYZE_BUNDLE=true ./node_modules/webpack/bin/webpack.js --watch --color -p",

--- a/packages/shift-react-components/src/components/checkout/checkout-steps.js
+++ b/packages/shift-react-components/src/components/checkout/checkout-steps.js
@@ -14,7 +14,7 @@ export function CheckoutSteps ({ currentStep, stepActions }) {
       { position: 1, title: 'Payment Method', href: '/checkout/payment-method' },
       { position: 2, title: 'Shipping Address', href: '/checkout/shipping-address' },
       { position: 3, title: 'Shipping Method', href: '/checkout/shipping-method' },
-      { position: 4, title: 'Payment', href: '/checkout/payment', as: '/checkout/payment', shallow: true },
+      { position: 4, title: 'Payment Details', href: '/checkout/payment', as: '/checkout/payment', shallow: true },
       { position: 5, title: 'Review & Submit' }
     ]
 


### PR DESCRIPTION
## Description

Small change to the labels for the checkout steps

![Screen Shot 2019-06-27 at 16 44 49](https://user-images.githubusercontent.com/6663840/60280518-fddee500-98fa-11e9-89d7-dbf5dcc9be5b.png)


## Related Issue

https://github.com/shiftcommerce/trendy-golf/issues/298

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [x] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

1. Go to checkout
2. "Payment" is now "Payment Details"

### Dependencies Review

N/A
