### PR TITLE
back out timing being an env var

### DIFF
--- a/packages/reference/client/pages/_app.js
+++ b/packages/reference/client/pages/_app.js
@@ -27,8 +27,7 @@ const {
     ENABLE_TEST_PAYPAL_BUTTON,
     ORDER_HISTORY_PAGE_LIMIT,
     PAYPAL_CLIENT_ID,
-    STRIPE_API_KEY,
-    SEARCH_DEBOUNCE_MS
+    STRIPE_API_KEY
   }
 } = getConfig()
 
@@ -49,8 +48,7 @@ shiftNextConfig.set({
   menuRequest: menuRequest,
   orderHistoryPageLimit: ORDER_HISTORY_PAGE_LIMIT,
   payPalClientID: PAYPAL_CLIENT_ID,
-  storeName: 'ShopGo',
-  searchDebounceMillisecs: SEARCH_DEBOUNCE_MS
+  storeName: 'ShopGo'
 })
 
 class MyApp extends App {

--- a/packages/reference/next.config.js
+++ b/packages/reference/next.config.js
@@ -19,8 +19,7 @@ module.exports = withBundleAnalyzer(withCSS(withSass(withTM({
     'ENABLE_TEST_PAYPAL_BUTTON': process.env.ENABLE_TEST_PAYPAL_BUTTON,
     'ORDER_HISTORY_PAGE_LIMIT': process.env.ORDER_HISTORY_PAGE_LIMIT,
     'PAYPAL_CLIENT_ID': process.env.PAYPAL_CLIENT_ID,
-    'STRIPE_API_KEY': process.env.STRIPE_API_KEY,
-    'SEARCH_DEBOUNCE_MS': process.env.SEARCH_DEBOUNCE_MS || 700
+    'STRIPE_API_KEY': process.env.STRIPE_API_KEY
   },
   serverRuntimeConfig: {
     'API_TENANT': process.env.API_TENANT,

--- a/packages/shift-react-components/src/components/search/search-bar.js
+++ b/packages/shift-react-components/src/components/search/search-bar.js
@@ -5,6 +5,8 @@ import { connectSearchBox } from 'react-instantsearch-dom'
 import debounce from 'lodash/debounce'
 import Config from '../../lib/config'
 
+const SEARCH_DEBOUNCE_MS = 1000
+
 class SearchBar extends Component {
   constructor (props) {
     super(props)
@@ -14,10 +16,8 @@ class SearchBar extends Component {
 
   handleChange (event) {
     const { refine } = this.props
-    const debounceTime = Config.get().searchDebounceMillisecs
-
     this.setState({ searchTerm: event.target.value })
-    debounce(() => refine(this.state.searchTerm), debounceTime)()
+    debounce(() => refine(this.state.searchTerm), SEARCH_DEBOUNCE_MS)()
   }
 
   render () {

--- a/packages/shift-react-components/src/components/search/search-bar.js
+++ b/packages/shift-react-components/src/components/search/search-bar.js
@@ -5,7 +5,7 @@ import { connectSearchBox } from 'react-instantsearch-dom'
 import debounce from 'lodash/debounce'
 import Config from '../../lib/config'
 
-const SEARCH_DEBOUNCE_MS = 1000
+const SEARCH_DEBOUNCE_MS = 800
 
 class SearchBar extends Component {
   constructor (props) {


### PR DESCRIPTION
## Description

backing out a change in #57 that made the debounce timing set by an env var because that wasn't done correctly and it results in more changes across the board

## Related Issue

shiftcommerce/trendy-golf#156

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [x] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

### Dependencies Review
n/a
