### PR TITLE
Custom LineItems component

### DIFF
--- a/packages/shift-react-components/src/components/cart/line-items.js
+++ b/packages/shift-react-components/src/components/cart/line-items.js
@@ -15,6 +15,7 @@ export class LineItems extends Component {
     super(props)
 
     this.Link = Config.get().Link || Link
+    this.LineItems = Config.get().LineItems
   }
 
   /**
@@ -137,14 +138,25 @@ export class LineItems extends Component {
    * @return {string} - HTML markup for the component
    */
   renderLineItems (lineItems) {
+    if (this.LineItems) {
+      return (
+        <this.LineItems
+          lineItems={lineItems}
+          lineItemsCount={this.props.lineItemsCount}
+          deleteItem={this.props.deleteItem}
+          updateQuantity={this.props.updateQuantity}
+        />
+      )
+    }
+
     const cartData = lineItems.sort((item1, item2) => parseInt(item1.id) - parseInt(item2.id)).map((lineItem) => {
-      const picture_url = lineItem.item.picture_url ? lineItem.item.picture_url : '/static/placeholder.png'
+      const pictureUrl = lineItem.item.picture_url ? lineItem.item.picture_url : '/static/placeholder.png'
 
       return (
         <div className={classNames('c-line-items__sections', { 'c-line-items__sections--error': (lineItem.unit_quantity > lineItem.stock_available_level) })} key={lineItem.item.sku}>
           <div className='c-line-items__images'>
             <this.Link href={`/slug?slug=${lineItem.item.product.canonical_path}`}>
-              <Image className='c-line-items__image' src={picture_url} alt={lineItem.item.title} key={lineItem.item.product.slug} aria-label={lineItem.item.title} />
+              <Image className='c-line-items__image' src={pictureUrl} alt={lineItem.item.title} key={lineItem.item.product.slug} aria-label={lineItem.item.title} />
             </this.Link>
           </div>
           <div className='c-line-items__information'>


### PR DESCRIPTION
## Description

This PR updates the LineItems component so that a custom LineItems component can be used instead

## Related Issue

https://github.com/shiftcommerce/trendy-golf/issues/296

### Checklist

- [x] Appropriate commenting on functions/components (JSDoc format).
- [ ] All SHIFT library versions bumped and published (utilised in this PR).
- [x] Unit tests added/amended.
- [x] Integration tests added/amended.
- [x] Environment variables supplied (.env.example also updated)

### How has/can this been tested?

- [x] Serverside rendering
- [x] Clientside rendering

1. Test in trendy
2. Add items to your cart
3. Go to checkout
4. Line items should be the trendy ones


### Dependencies Review

N/A
